### PR TITLE
Fix windows install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ class ve_build_ext(build_ext):
 
 
 def read(fname):
-    with open(fname, , encoding="utf8") as fp:
+    with open(fname, encoding="utf8") as fp:
         content = fp.read()
     return content
 

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ class ve_build_ext(build_ext):
 
 
 def read(fname):
-    with open(fname) as fp:
+    with open(fname, , encoding="utf8") as fp:
         content = fp.read()
     return content
 


### PR DESCRIPTION
Fixed an issue with `setup.py` that made the install fail on Windows 10 Python 3.7.2 (maybe something env specific, but in any case specifying the encoding can't hurt).