### PR TITLE
Allow the use of httpx.AsyncClient in addition to aiohttp.ClientSession

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup_opts = dict(
     packages=find_packages(exclude=('test*',)),
     package_dir={'aiochclient': 'aiochclient'},
     include_package_data=True,
-    install_requires=['aiohttp>=3.0.1', 'sqlparse>=0.3.0'],
+    install_requires=['aiohttp>=3.0.1', 'sqlparse>=0.3.0', 'httpx>=0.12'],
     license='MIT',
     url='https://github.com/maximdanilchenko/aiochclient',
     zip_safe=False,


### PR DESCRIPTION
This is a (dirty) preliminary exemple of it looks like.
I guess we need another abstraction.

`httpx.AsyncClient` does not provide any `readline()` as `bytes`. It convert to `str` and gives the encoding. So the `*Fabric` should be modified as well.

I initiated this because I have a **lot** of TCP client reset with aiohttp. No resets with httpx.