### PR TITLE
Json boosting

### DIFF
--- a/aiochclient/client.py
+++ b/aiochclient/client.py
@@ -1,8 +1,9 @@
-import orjson as json_
 import warnings
 from enum import Enum
 from types import TracebackType
 from typing import Any, AsyncGenerator, Dict, List, Optional, Type
+
+import orjson as json_
 
 from aiochclient.exceptions import ChClientError
 from aiochclient.http_clients.abc import HttpClientABC

--- a/aiochclient/client.py
+++ b/aiochclient/client.py
@@ -1,4 +1,4 @@
-import json as json_
+import orjson as json_
 import warnings
 from enum import Enum
 from types import TracebackType

--- a/benchmarks.py
+++ b/benchmarks.py
@@ -68,6 +68,7 @@ def row_data():
         uuid.uuid4(),
     )
 
+
 def json_data():
     return {
         "a": 1,
@@ -80,8 +81,9 @@ def json_data():
         "h": "hello",
         "j": None,
         "k": ["q", "w", "e", "r"],
-        "u": uuid.uuid4()
+        "u": uuid.uuid4(),
     }
+
 
 async def prepare_db(client):
     await client.execute("DROP TABLE IF EXISTS benchmark_tbl")
@@ -173,6 +175,7 @@ async def bench_inserts(*, retries: int, rows: int):
     )
     print(f"  Speed: {speed} rows/sec")
 
+
 async def bench_inserts_json(*, retries: int, rows: int):
     print("AIOCHCLIENT json inserts")
     async with ClientSession() as s:
@@ -184,7 +187,8 @@ async def bench_inserts_json(*, retries: int, rows: int):
         start_time = time.time()
         for _ in range(retries):
             await client.execute(
-                "INSERT INTO benchmark_tbl FORMAT JSONEachRow", *(one_row for _ in range(rows))
+                "INSERT INTO benchmark_tbl FORMAT JSONEachRow",
+                *(one_row for _ in range(rows)),
             )
         total_time = time.time() - start_time
         avg_time = total_time / retries

--- a/benchmarks.py
+++ b/benchmarks.py
@@ -33,6 +33,9 @@ selects with decoding
 inserts
 - Avg time for inserting 10000 rows from 100 runs: 0.13569785118103028 sec. Total: 13.569785118103027
   Speed: 73693 rows/sec
+json inserts
+- Avg time for inserting 10000 rows from 100 runs: 0.039186043739318846 sec. Total: 3.9186043739318848
+  Speed: 255192 rows/sec
 AIOCH
 selects with decoding
 - Avg time for selecting 10000 rows from 100 runs: 0.32889273166656496 sec. Total: 32.889273166656494
@@ -171,7 +174,7 @@ async def bench_inserts(*, retries: int, rows: int):
     print(f"  Speed: {speed} rows/sec")
 
 async def bench_inserts_json(*, retries: int, rows: int):
-    print("AIOCHCLIENT inserts")
+    print("AIOCHCLIENT json inserts")
     async with ClientSession() as s:
         client = ChClient(s, compress_response=True)
         # prepare environment

--- a/dev-requirements/dev-requirements-ciso.txt
+++ b/dev-requirements/dev-requirements-ciso.txt
@@ -12,3 +12,4 @@ sphinx_rtd_theme
 black
 isort==4.3.21
 ciso8601>=2.1.1
+orjson>=3.3.1

--- a/dev-requirements/dev-requirements.txt
+++ b/dev-requirements/dev-requirements.txt
@@ -11,3 +11,4 @@ sphinx_issues
 sphinx_rtd_theme
 black
 isort==4.3.21
+orjson>=3.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 aiohttp>=3.0.1
 ciso8601>=2.1.1
 sqlparse>=0.3.0
+orjson>=3.3.1


### PR DESCRIPTION
Hi again.I have run many benchmarks with different json python libraries (orjson, rapidjson) and concluded, that orjson demonstrates extremly high performance for clickhouse-like usage patterns (inserting large batch of records).I even can't understand, why it runs better than TSV.In addition, orjson allows datetime serialization(Native python date and time format).So, I replaced native json library with orjson.Do you mind replacing it?