### PR TITLE
fetch non sql commands results (describe, show)

### DIFF
--- a/aiochclient/client.py
+++ b/aiochclient/client.py
@@ -224,7 +224,9 @@ class ChClient:
 
         :return: Nothing.
         """
-        async for _ in self._execute(query, *args, json=json, query_params=params, query_id=query_id):
+        async for _ in self._execute(
+            query, *args, json=json, query_params=params, query_id=query_id
+        ):
             return None
 
     async def fetch(
@@ -252,7 +254,9 @@ class ChClient:
         """
         return [
             row
-            async for row in self._execute(query, *args, json=json, query_params=params, query_id=query_id)
+            async for row in self._execute(
+                query, *args, json=json, query_params=params, query_id=query_id
+            )
         ]
 
     async def fetchrow(
@@ -280,7 +284,9 @@ class ChClient:
 
         :return: First row from query or None if there no results.
         """
-        async for row in self._execute(query, *args, json=json, query_params=params, query_id=query_id):
+        async for row in self._execute(
+            query, *args, json=json, query_params=params, query_id=query_id
+        ):
             return row
         return None
 
@@ -316,7 +322,9 @@ class ChClient:
 
         :return: First value of the first row or None if there no results.
         """
-        async for row in self._execute(query, *args, json=json, query_params=params, query_id=query_id):
+        async for row in self._execute(
+            query, *args, json=json, query_params=params, query_id=query_id
+        ):
             if row:
                 return row[0]
         return None
@@ -353,7 +361,9 @@ class ChClient:
 
         :return: Rows one by one.
         """
-        async for row in self._execute(query, *args, json=json, query_params=params, query_id=query_id):
+        async for row in self._execute(
+            query, *args, json=json, query_params=params, query_id=query_id
+        ):
             yield row
 
     async def cursor(self, query: str, *args) -> AsyncGenerator[Record, None]:

--- a/aiochclient/sql.py
+++ b/aiochclient/sql.py
@@ -26,8 +26,15 @@ class Where(sqlparse.sql.TokenList):
 
 sqlparse.sql.Where = Where
 
-KEYWORDS_COMMON['FORMAT'] = tokens.Keyword.DML
-SQL_REGEX = {'clickhouse-ext': [('FORMAT', sqlparse.tokens.Keyword)]}
+KEYWORDS_COMMON['FORMAT'] = tokens.Keyword
+KEYWORDS_COMMON['DESCRIBE'] = tokens.Keyword.DML
+KEYWORDS_COMMON['SHOW'] = tokens.Keyword.DML
+SQL_REGEX = {
+    'clickhouse-ext': [
+        ('FORMAT\b', sqlparse.tokens.Keyword),
+        ('(DESCRIBE|SHOW)\b', sqlparse.tokens.Keyword.DML),
+    ]
+}
 
 FLAGS = re.IGNORECASE | re.UNICODE
 SQL_REGEX = [

--- a/tests.py
+++ b/tests.py
@@ -533,6 +533,17 @@ class TestFetching:
     async def test_select_with_execute(self):
         assert (await self.ch.execute("SELECT * FROM all_types WHERE uint8=1")) is None
 
+    async def test_describe_with_fetch(self):
+        described_columns = await self.ch.fetch("DESCRIBE TABLE all_types", json=True)
+        assert described_columns is not None
+        assert 'type' in described_columns[0]
+        assert 'name' in described_columns[0]
+
+    async def test_show_tables_with_fetch(self):
+        tables = await self.ch.fetch("SHOW TABLES")
+        assert len(tables) == 1
+        assert tables[0]._row.decode() == 'all_types'
+
 
 @pytest.mark.record
 @pytest.mark.usefixtures("class_chclient")


### PR DESCRIPTION
i found the reason why the fetch command returns `None` for these expressions:  'SHOW', 'DESCRIBE'.
This happens because the library `sqlparse` does not know that this command is a DML-command in clickhouse.
`statement.get_type()` return `'UNKNOWN'` for this commands and self.fetch() return None (because flag need_fetch will set to False in this case).
```
statement = sqlparse.parse(query)[0]
statement_type = statement.get_type()
if statement_type in ('SELECT', 'SHOW', 'DESCRIBE', 'EXISTS'):
    need_fetch = True
else:
    need_fetch = False
```
In my MR i fixed it