### PR TITLE
Fix aiohttp ValueError: Line is too long

### DIFF
--- a/aiochclient/http_clients/aiohttp.py
+++ b/aiochclient/http_clients/aiohttp.py
@@ -32,8 +32,7 @@ class AiohttpHttpClient(HttpClientABC):
                 buffer = lines.pop(-1)
                 for line in lines:
                     yield line + self.line_separator
-            if buffer:
-                yield buffer + self.line_separator
+            assert not buffer
 
     async def post_no_return(self, url: str, params: dict, data: Any) -> None:
         async with self._session.post(url=url, params=params, data=data) as resp:

--- a/aiochclient/http_clients/aiohttp.py
+++ b/aiochclient/http_clients/aiohttp.py
@@ -1,4 +1,4 @@
-from typing import Any, AsyncGenerator, Optional
+from typing import Any, AsyncGenerator, List, Optional
 
 from aiohttp import ClientSession
 
@@ -7,6 +7,8 @@ from aiochclient.http_clients.abc import HttpClientABC
 
 
 class AiohttpHttpClient(HttpClientABC):
+    line_separator: bytes = b'\n'
+
     def __init__(self, session: Optional[ClientSession]):
         if session:
             self._session = session
@@ -22,8 +24,16 @@ class AiohttpHttpClient(HttpClientABC):
     ) -> AsyncGenerator[bytes, None]:
         async with self._session.post(url=url, params=params, data=data) as resp:
             await _check_response(resp)
-            async for line in resp.content:
-                yield line
+
+            buffer: bytes = b''
+            async for chunk in resp.content.iter_any():
+                lines: List[bytes] = chunk.split(line_separator)
+                lines[0] = buffer + lines[0]
+                buffer = lines.pop(-1)
+                for line in lines:
+                    yield line + line_separator
+            if buffer:
+                yield buffer + line_separator
 
     async def post_no_return(self, url: str, params: dict, data: Any) -> None:
         async with self._session.post(url=url, params=params, data=data) as resp:

--- a/aiochclient/http_clients/aiohttp.py
+++ b/aiochclient/http_clients/aiohttp.py
@@ -27,13 +27,13 @@ class AiohttpHttpClient(HttpClientABC):
 
             buffer: bytes = b''
             async for chunk in resp.content.iter_any():
-                lines: List[bytes] = chunk.split(line_separator)
+                lines: List[bytes] = chunk.split(self.line_separator)
                 lines[0] = buffer + lines[0]
                 buffer = lines.pop(-1)
                 for line in lines:
-                    yield line + line_separator
+                    yield line + self.line_separator
             if buffer:
-                yield buffer + line_separator
+                yield buffer + self.line_separator
 
     async def post_no_return(self, url: str, params: dict, data: Any) -> None:
         async with self._session.post(url=url, params=params, data=data) as resp:


### PR DESCRIPTION
Error when iterating over a result containing long lines
```
  File ".../site-packages/aiochclient/client.py", line 181, in _execute
    async for line in resp.content:
  File ".../site-packages/aiohttp/streams.py", line 39, in __anext__
    rv = await self.read_func()
  File ".../site-packages/aiohttp/streams.py", line 322, in readline
    raise ValueError('Line is too long')
ValueError: Line is too long
```