### PR TITLE
Named tuple partial support (transformed into a simple tuple)

### DIFF
--- a/aiochclient/_types.pyx
+++ b/aiochclient/_types.pyx
@@ -401,7 +401,7 @@ cdef class TupleType:
         self.name = name
         self.container = container
         cdef str tps = RE_TUPLE.findall(name)[0]
-        self.types = tuple(what_py_type(tp, container=True).p_type for tp in tps.split(","))
+        self.types = tuple(what_py_type(tp.rpartition(" ")[2], container=True).p_type for tp in tps.split(","))
 
     cdef tuple _convert(self, str string):
         return tuple(

--- a/aiochclient/types.py
+++ b/aiochclient/types.py
@@ -257,7 +257,9 @@ class TupleType(BaseType):
     def __init__(self, name: str, **kwargs):
         super().__init__(name, **kwargs)
         tps = RE_TUPLE.findall(name)[0]
-        self.types = tuple(what_py_type(tp, container=True) for tp in tps.split(","))
+        self.types = tuple(
+            what_py_type(tp.rpartition(" ")[2], container=True) for tp in tps.split(",")
+        )
 
     def p_type(self, string: str) -> tuple:
         return tuple(

--- a/tests.py
+++ b/tests.py
@@ -686,6 +686,18 @@ class TestTypes:
         assert record[0] == result
         assert record["datetime"] == result
 
+    async def test_named_tuples(self):
+        """Named tuples are used for example in geohash functions
+
+        https://clickhouse.com/docs/en/sql-reference/data-types/tuple/#addressing-tuple-elements
+        """
+
+        result = await self.ch.fetchval(
+            f"SELECT (1.0, 2.0)::Tuple(x Float64, y Float64)"
+        )
+        assert round(result[0]) == 1
+        assert round(result[1]) == 2
+
 
 @pytest.mark.fetching
 @pytest.mark.usefixtures("class_chclient")


### PR DESCRIPTION
`geohashDecode()` builtin function returns a `named_tuple` and not a standard `Tuple`.

named_tuple in CH: https://clickhouse.com/docs/en/sql-reference/data-types/tuple/#addressing-tuple-elements

Maybe we would like to have a better support of named tuple by converting them into python `NamedTuple`
But at least with this patch a namedtuple can be used and will not crash the `aiochclient` code.

This closes the issue https://github.com/maximdanilchenko/aiochclient/issues/63 - geohash functions can now be used.