### PR TITLE
user that don't use query_params should be able to set field aliases they want

### DIFF
--- a/aiochclient/client.py
+++ b/aiochclient/client.py
@@ -140,7 +140,8 @@ class ChClient:
         decode: bool = True,
     ) -> AsyncGenerator[Record, None]:
         query_params = self._prepare_query_params(query_params)
-        query = query.format(**query_params)
+        if query_params:
+            query = query.format(**query_params)
         need_fetch, is_json, statement_type = self._parse_squery(query)
 
         if not is_json and json:

--- a/tests.py
+++ b/tests.py
@@ -795,6 +795,11 @@ class TestFetching:
         exists = await self.ch.fetchrow("EXISTS TABLE all_types")
         assert exists == {'result': 1}
 
+    async def test_no_params(self):
+        """It should be possible to have the aliases we want if we don't use any params"""
+        res = await self.ch.fetchrow('SELECT 1 AS "{not_a_param}" FROM all_types')
+        assert res["{not_a_param}"] == 1
+
 
 @pytest.mark.record
 @pytest.mark.usefixtures("class_chclient")


### PR DESCRIPTION
Aliases are sometimes used as pointer to be able to find data in the results.
I found that it's not possible to create an alias as `{alias}` because of query params formating.
I propose a patch that just don't execute le `.format()` if not necessary. Should be transparent for everyone.
