### PR TITLE
Enable auto mode for pytest-asyncio

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,3 +10,4 @@ exclude = '''
 '''
 [tool.pytest.ini_options]
 markers = ["types", "fetching", "client", "record"]
+asyncio_mode = "auto"


### PR DESCRIPTION
Tests can't be run when using `pytest-asyncio>=0.19`:

```
    async def select_field(self, field):
>       return await self.ch.fetchval(f"SELECT {field} FROM all_types WHERE uint8=1")
E       AttributeError: 'async_generator' object has no attribute 'fetchval'
```

(See https://github.com/pytest-dev/pytest-asyncio/releases/tag/v0.19.0 § Modes)

Enabling the `auto` mode allows tests to run properly.