### PR TITLE
Use headers instead of query parameters to pass authentication data

### DIFF
--- a/aiochclient/http_clients/abc.py
+++ b/aiochclient/http_clients/abc.py
@@ -6,17 +6,19 @@ from aiochclient.exceptions import ChClientError
 
 class HttpClientABC(ABC):
     @abstractmethod
-    async def get(self, url: str, params: dict) -> None:
+    async def get(self, url: str, params: dict, headers: dict) -> None:
         """Use aiochclient.exceptions.ChClientError in case of bad status code"""
 
     @abstractmethod
     async def post_return_lines(
-        self, url: str, params: dict, data: Any
+        self, url: str, params: dict, headers: dict, data: Any
     ) -> AsyncGenerator[bytes, None]:
         """Use aiochclient.exceptions.ChClientError in case of bad status code"""
 
     @abstractmethod
-    async def post_no_return(self, url: str, params: dict, data: Any) -> None:
+    async def post_no_return(
+        self, url: str, params: dict, headers: dict, data: Any
+    ) -> None:
         """Use aiochclient.exceptions.ChClientError in case of bad status code"""
 
     @abstractmethod

--- a/aiochclient/http_clients/aiohttp.py
+++ b/aiochclient/http_clients/aiohttp.py
@@ -15,14 +15,16 @@ class AiohttpHttpClient(HttpClientABC):
         else:
             self._session = ClientSession()
 
-    async def get(self, url: str, params: dict) -> None:
-        async with self._session.get(url=url, params=params) as resp:
+    async def get(self, url: str, params: dict, headers: dict) -> None:
+        async with self._session.get(url=url, params=params, headers=headers) as resp:
             await _check_response(resp)
 
     async def post_return_lines(
-        self, url: str, params: dict, data: Any
+        self, url: str, params: dict, headers: dict, data: Any
     ) -> AsyncGenerator[bytes, None]:
-        async with self._session.post(url=url, params=params, data=data) as resp:
+        async with self._session.post(
+            url=url, params=params, headers=headers, data=data
+        ) as resp:
             await _check_response(resp)
 
             buffer: bytes = b''
@@ -34,8 +36,12 @@ class AiohttpHttpClient(HttpClientABC):
                     yield line + self.line_separator
             assert not buffer
 
-    async def post_no_return(self, url: str, params: dict, data: Any) -> None:
-        async with self._session.post(url=url, params=params, data=data) as resp:
+    async def post_no_return(
+        self, url: str, params: dict, headers: dict, data: Any
+    ) -> None:
+        async with self._session.post(
+            url=url, params=params, headers=headers, data=data
+        ) as resp:
             await _check_response(resp)
 
     async def close(self) -> None:

--- a/aiochclient/http_clients/httpx.py
+++ b/aiochclient/http_clients/httpx.py
@@ -13,20 +13,26 @@ class HttpxHttpClient(HttpClientABC):
         else:
             self._session = AsyncClient()
 
-    async def get(self, url: str, params: dict) -> None:
-        resp = await self._session.get(url=url, params=params)
+    async def get(self, url: str, params: dict, headers: dict) -> None:
+        resp = await self._session.get(url=url, params=params, headers=headers)
         await _check_response(resp)
 
     async def post_return_lines(
-        self, url: str, params: dict, data: Any
+        self, url: str, params: dict, headers: dict, data: Any
     ) -> AsyncGenerator[bytes, None]:
-        resp = await self._session.post(url=url, params=params, content=data)
+        resp = await self._session.post(
+            url=url, params=params, headers=headers, content=data
+        )
         await _check_response(resp)
         async for line in resp.aiter_lines():
             yield line.encode()
 
-    async def post_no_return(self, url: str, params: dict, data: Any) -> None:
-        resp = await self._session.post(url=url, params=params, content=data)
+    async def post_no_return(
+        self, url: str, params: dict, headers: dict, data: Any
+    ) -> None:
+        resp = await self._session.post(
+            url=url, params=params, headers=headers, content=data
+        )
         await _check_response(resp)
 
     async def close(self) -> None:


### PR DESCRIPTION
Fixes https://github.com/maximdanilchenko/aiochclient/issues/79 (query parameters can be leaked: e.g. in the `aiohttp.ClientOSError` exception or by proxy's access log).