### PR TITLE
Dependencies upgrade, lint

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -2,6 +2,5 @@
 known_third_party = uvloop,aioch
 skip = venv
 multi_line_output = 3
-recursive = true
 include_trailing_comma = true
 line_length = 88

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 format:
-	isort -y
+	isort .
 	black .
 
 test:

--- a/aiochclient/_types.pyx
+++ b/aiochclient/_types.pyx
@@ -1,15 +1,23 @@
 #cython: language_level=3
-import re
 import json
+import re
 from decimal import Decimal
 from ipaddress import IPv4Address, IPv6Address
 from uuid import UUID
 
+from cpython cimport PyList_Append, PyUnicode_AsEncodedString, PyUnicode_Join
 from cpython.datetime cimport date, datetime
-from cpython cimport PyUnicode_Join, PyUnicode_AsEncodedString, PyList_Append
-from cpython.mem cimport PyMem_Malloc, PyMem_Free
-from libc.stdint cimport (int8_t, int16_t, int32_t, int64_t,
-                          uint8_t, uint16_t, uint32_t, uint64_t)
+from cpython.mem cimport PyMem_Free, PyMem_Malloc
+from libc.stdint cimport (
+    int8_t,
+    int16_t,
+    int32_t,
+    int64_t,
+    uint8_t,
+    uint16_t,
+    uint32_t,
+    uint64_t,
+)
 
 from aiochclient.exceptions import ChClientError
 

--- a/aiochclient/client.py
+++ b/aiochclient/client.py
@@ -11,9 +11,9 @@ from aiochclient.sql import sqlparse
 
 # Optional cython extension:
 try:
-    from aiochclient._types import rows2ch, json2ch, py2ch
+    from aiochclient._types import json2ch, py2ch, rows2ch
 except ImportError:
-    from aiochclient.types import rows2ch, json2ch, py2ch
+    from aiochclient.types import json2ch, py2ch, rows2ch
 
 
 class QueryTypes(Enum):

--- a/aiochclient/records.py
+++ b/aiochclient/records.py
@@ -3,9 +3,9 @@ from typing import Any, Callable, Dict, Iterator, List, Tuple, Union
 
 # Optional cython extension:
 try:
-    from aiochclient._types import what_py_converter, empty_convertor
+    from aiochclient._types import empty_convertor, what_py_converter
 except ImportError:
-    from aiochclient.types import what_py_converter, empty_convertor
+    from aiochclient.types import empty_convertor, what_py_converter
 
 __all__ = ["RecordsFabric", "Record", "FromJsonFabric"]
 

--- a/dev-requirements/dev-requirements-ciso.txt
+++ b/dev-requirements/dev-requirements-ciso.txt
@@ -1,6 +1,6 @@
-aiohttp>=3.0.1
+aiohttp>=3.8.4
 httpx
-sqlparse>=0.3.0
+sqlparse>=0.4.3
 pytest
 pytest-cov
 pytest-sugar
@@ -10,5 +10,5 @@ sphinx
 sphinx_issues
 sphinx_rtd_theme
 black
-isort==4.3.21
-ciso8601>=2.1.1
+isort==5.12.0
+ciso8601>=2.3.0

--- a/dev-requirements/dev-requirements.txt
+++ b/dev-requirements/dev-requirements.txt
@@ -1,6 +1,6 @@
-aiohttp>=3.0.1
+aiohttp>=3.8.4
 httpx
-sqlparse>=0.3.0
+sqlparse>=0.4.3
 pytest
 pytest-cov
 pytest-sugar
@@ -10,4 +10,4 @@ sphinx
 sphinx_issues
 sphinx_rtd_theme
 black
-isort==4.3.21
+isort==5.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-sqlparse>=0.3.0
+sqlparse>=0.4.3

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup_opts = dict(
     packages=find_packages(exclude=('test*',)),
     package_dir={'aiochclient': 'aiochclient'},
     include_package_data=True,
-    install_requires=['sqlparse>=0.3.0'],
+    install_requires=['sqlparse>=0.4.3'],
     license='MIT',
     url='https://github.com/maximdanilchenko/aiochclient',
     zip_safe=False,
@@ -78,11 +78,11 @@ setup_opts = dict(
     ext_modules=extensions,
     extras_require={
         # aiohttp client
-        'aiohttp': ['aiohttp>=3.0.1'],
-        'aiohttp-speedups': ['aiodns', 'cchardet', 'ciso8601>=2.1.1', 'aiohttp>=3.0.1'],
+        'aiohttp': ['aiohttp>=3.8.4'],
+        'aiohttp-speedups': ['aiodns', 'cchardet', 'ciso8601>=2.3.0', 'aiohttp>=3.8.4'],
         # httpx client
         'httpx': ['httpx'],
-        'httpx-speedups': ['ciso8601>=2.1.1', 'httpx'],
+        'httpx-speedups': ['ciso8601>=2.3.0', 'httpx'],
     },
     cmdclass=dict(build_ext=ve_build_ext),
 )


### PR DESCRIPTION
This merge request fixes aiochclient[aiohttp-speedups] build errors for python 3.11  
Build failed with error:
```
src/cchardet/_cchardet.cpp:196:12: fatal error: longintrepr.h: No such file or directory
```
Which was fixed with aiohttp 3.8+