### PR TITLE
bump sqlparse version and don't use a compiled regex

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-sqlparse>=0.4.3
+sqlparse>=0.4.4


### PR DESCRIPTION
sqlparse just had a new release yesterday: https://github.com/andialbrecht/sqlparse

This new release introduce an internal change with the behavior of `SQL_REGEX`, where they don't compile the regex directly but further in the code, who make currently an incompatibility with the latest release.

How sqlparse did it on the 0.4.3: https://github.com/andialbrecht/sqlparse/blob/fba15d34a01739c10596d727e20b89762298eea8/sqlparse/keywords.py#L28-L109
How sqlparse do it currently: https://github.com/andialbrecht/sqlparse/blob/master/sqlparse/keywords.py#L16-L93

With taking a look on the sqlparse documentation, it seems we can extend it, so the overloading of clickhouse operator has been written on-part with their documentation: https://sqlparse.readthedocs.io/en/latest/extending/

Closes #89 