### PR TITLE
fix Map type issue

### DIFF
--- a/aiochclient/_types.pyx
+++ b/aiochclient/_types.pyx
@@ -469,7 +469,7 @@ cdef class  MapType:
             dict_from_string = json.loads(string.replace("'", '"'))
         else:
             dict_from_string = string
-        return {self.key_type.p_type(key): self.value_type.p_type(val) for key, val in dict_from_string.items()}
+        return {self.key_type.p_type(key): self.value_type.p_type(str(val)) for key, val in dict_from_string.items()}
 
     cpdef dict p_type(self, string):
         return self._convert(string)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,3 +11,5 @@ exclude = '''
 [tool.pytest.ini_options]
 markers = ["types", "fetching", "client", "record"]
 asyncio_mode = "auto"
+[build-system]
+requires = ["setuptools", "wheel", "Cython"]


### PR DESCRIPTION
When load data with json.loads, it converts number to int. But when later use value type to convert it, it requires str and raises exception. So convert it back to str should be the safest way to resolve this issue. We may also use the data type converted by json.loads, but it may not match ClickHouse's data type in edge cases.

this fixes #94 

Also add [build-system] to pyproject.toml, which is required by current pip/poetry/etc. to properly build cython extensions.