### PR TITLE
escape quoted string for container type on cython parser

### DIFF
--- a/aiochclient/sql.py
+++ b/aiochclient/sql.py
@@ -2,7 +2,7 @@ import re
 
 import sqlparse.keywords
 from sqlparse import tokens
-from sqlparse.keywords import KEYWORDS_COMMON, KEYWORDS
+from sqlparse.keywords import KEYWORDS, KEYWORDS_COMMON
 from sqlparse.lexer import Lexer
 
 

--- a/tests.py
+++ b/tests.py
@@ -931,12 +931,12 @@ class TestFetching:
         record = await self.ch.fetchrow("SELECT 'foo\\'bar' AS quoted_string")
         assert record == {'quoted_string': "foo'bar"}
 
-    @pytest.mark.skip  # TODO: unskip after cython quoted string fix
     async def test_quoted_string_array(self):
-        record = await self.ch.fetchrow("SELECT ['foo\\'foo', 'bar', 'foo\\\\'] as array")
+        record = await self.ch.fetchrow(
+            "SELECT ['foo\\'foo', 'bar', 'foo\\\\'] as array"
+        )
         assert record == {'array': ["foo'foo", 'bar', 'foo\\']}
 
-    @pytest.mark.skip  # TODO: unskip after cython quoted string fix
     async def test_quoted_string_tuple(self):
         record = await self.ch.fetchrow("SELECT ('foo\\'foo', 'bar') as tuple")
         assert record == {
@@ -946,7 +946,6 @@ class TestFetching:
             )
         }
 
-    @pytest.mark.skip  # TODO: unskip after cython quoted string fix
     async def test_quoted_string_map(self):
         record = await self.ch.fetchrow("SELECT map('foo\\'foo', 'bar\\'bar') as map")
         assert record == {'map': {"foo'foo": "bar'bar"}}


### PR DESCRIPTION
followup PR of https://github.com/maximdanilchenko/aiochclient/pull/92, I saw that the tests has been disabled as the quoted string parsing wasn't present on the parser made in cython