### PR TITLE
Have `Map` types use the unconversions of other types

### DIFF
--- a/aiochclient/_types.pyx
+++ b/aiochclient/_types.pyx
@@ -828,7 +828,11 @@ cdef bytes unconvert_tuple(tuple value):
     return b"(" + b",".join(py2ch(elem) for elem in value) + b")"
 
 cdef bytes unconvert_dict(dict value):
-    return json2ch(value, dumps=json.dumps).replace('"', "'").encode()
+    return (
+        b"{" +
+        b','.join(py2ch(key) + b':' + py2ch(val) for key, val in value.items()) +
+        b"}"
+    )
 
 cdef bytes unconvert_array(list value):
     return b"[" + b",".join(py2ch(elem) for elem in value) + b"]"

--- a/aiochclient/types.py
+++ b/aiochclient/types.py
@@ -335,7 +335,11 @@ class MapType(BaseType):
 
     @staticmethod
     def unconvert(value) -> bytes:
-        return json2ch(value, dumps=json.dumps).replace('"', "'").encode()
+        return (
+            b"{"
+            + b','.join(py2ch(key) + b':' + py2ch(val) for key, val in value.items())
+            + b"}"
+        )
 
 
 class ArrayType(BaseType):

--- a/tests.py
+++ b/tests.py
@@ -70,8 +70,8 @@ def rows(uuid):
             IPv6Address('2001:44c8:129:2632:33:0:252:2'),
             dt.datetime(2018, 9, 21, 10, 32, 23, 999000),
             True,
-            {"hello": "world"},
-            {"hello": {"inner": "world"}},
+            {"hello": "world {' and other things"},
+            {"hello": {"inner": "world {' and other things"}},
             [(1, 2), (3, 4)],
             [('hello', dt.date(2018, 9, 21)), ('world', dt.date(2018, 9, 22))],
         ],
@@ -122,8 +122,8 @@ def rows(uuid):
             None,
             dt.datetime(2019, 1, 1, 3, 0),
             False,
-            {"hello": "world"},
-            {"hello": {"inner": "world"}},
+            {"hello": "world {'"},
+            {"hello": {"inner": "world {'"}},
             [(0, 1)],
             [
                 ('hello', dt.date(2018, 9, 21)),
@@ -597,26 +597,26 @@ class TestTypes:
         assert record["tuple"] == result
 
     async def test_map(self):
-        result = {"hello": "world"}
+        result = {"hello": "world {' and other things"}
         assert await self.select_field("map") == result
         record = await self.select_record("map")
         assert record[0] == result
         assert record["map"] == result
 
-        result = b"{'hello':'world'}"
+        result = b"{'hello':'world {\\' and other things'}"
         assert await self.select_field_bytes("map") == result
         record = await self.select_record_bytes("map")
         assert record[0] == result
         assert record["map"] == result
 
     async def test_map_map(self):
-        result = {"hello": {"inner": "world"}}
+        result = {"hello": {"inner": "world {' and other things"}}
         assert await self.select_field("map_map") == result
         record = await self.select_record("map_map")
         assert record[0] == result
         assert record["map_map"] == result
 
-        result = b"{'hello':{'inner':'world'}}"
+        result = b"{'hello':{'inner':'world {\\' and other things'}}"
         assert await self.select_field_bytes("map_map") == result
         record = await self.select_record_bytes("map_map")
         assert record[0] == result
@@ -1094,9 +1094,7 @@ class TestJson:
         result = await self.ch.fetch(
             "SELECT nested_int, nested_str_date FROM all_types WHERE has(nested_int.value1, 0) format JSONEachRow"
         )
-        assert result[0]['nested_int'] == [
-            [0, 1]
-        ]
+        assert result[0]['nested_int'] == [[0, 1]]
         assert result[0]['nested_str_date'] == [
             ['hello', '2018-09-21'],
             ['inner', '2018-09-22'],


### PR DESCRIPTION
Before this change, `Map` types would dump the incoming `dict`s as JSON, but this wouldn't take into account any additional encoding of values unique to ClickHouse.  For example, in a `Map(String, String)`, a string with embedded quotes and curly braces may end up with an exception like:

```
ChClientError: Code: 62. DB::Exception: Cannot parse expression of type Map(String, String)
```