### PR TITLE
Fix issue #14 with select empty string & fix test Nested  with format JSONEachRow

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -1039,8 +1039,6 @@ class TestRecord:
         records = await self.ch.fetch(
             "SELECT uniq(array_string) FROM all_types GROUP BY array_string WITH TOTALS"
         )
-        print([dict(i) for i in records])
-        # print(records[-2])
         assert bool(records[-2]) is False
 
     async def test_len(self):

--- a/tests.py
+++ b/tests.py
@@ -971,7 +971,7 @@ class TestFetching:
 
     async def test_show_tables_with_fetch(self):
         tables = await self.ch.fetch("SHOW TABLES")
-        assert len(tables) == 19
+        assert len(tables) == 3
         assert tables[0]._row.decode() == 'all_types'
 
     async def test_aggr_merge_tree(self):


### PR DESCRIPTION
## 1. Attempts to select empty strings returns empty strings or raise exceptions

When we have `String` column which include empty values `''` than we have key error
```sql
CREATE TABLE default.some_table
(
    `str_column` String
)
ENGINE = MergeTree
ORDER BY str_column
```

```python
rows = await client.fetch("select str_column from some_table where str_column = ''")
for i in rows:
    print(i['str_column'])
        
line 55, in _getitem
    raise KeyError(
KeyError: "Empty row. May be it is result of 'WITH TOTALS' query."
Unclosed client session
```

or during coversion to `dict` empty strings just dissappear:
```python
rows = await client.fetch("select str_column from some_table where str_column = ''")
for i in rows:
    print(dict(i))     
{}
{}
```
We can get this rows only with using `format JSONEachRow`

```python
rows = await client.fetch("SELECT str_column FROM some_table WHERE str_column = '' format JSONEachRow")
for i in rows:
    print(i)
{'str_column': ''}
{'str_column': ''}
```

### So after this PR everything works fine:
(the first example in which there was an exception before)
```python
rows = await client.fetch("SELECT str_column FROM some_table WHERE str_column = ''")
for i in rows:
    print(dict(i)) 
{'str_column': ''}
{'str_column': ''}
```

## 2. Fix Nested field test

When we use flatten Nested with `format JSONEachRow` ClickHouse returns list of dicts (without formatting its list of tuples).
Everything works as it should, but test had the wrong assert with list of lists and I update it to correct value.
Perhaps something work wrong before this PR and I missed it whed adding the Nested field, but after fix empty string everything works:

```python
rows = await client.fetch("SELECT nested_int, nested_str_date FROM all_types WHERE has(nested_int.value1, 0) format JSONEachRow")
for i in rows:
    print(i)
{'nested_int': [{'value1': 0, 'value2': 1}], 'nested_str_date': [{'value1': 'hello', 'value2': '2018-09-21'}, {'value1': 'inner', 'value2': '2018-09-22'}, {'value1': 'world', 'value2': '2018-09-23'}]}    
        

