### PR TITLE
Fix build `aiohttp-speedups`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ setup_opts = dict(
     extras_require={
         # aiohttp client
         'aiohttp': ['aiohttp>=3.8.4'],
-        'aiohttp-speedups': ['aiodns', 'cchardet', 'ciso8601>=2.3.0', 'aiohttp>=3.8.4'],
+        'aiohttp-speedups': ['aiodns', 'faust-cchardet', 'ciso8601>=2.3.0', 'aiohttp>=3.8.4'],
         # httpx client
         'httpx': ['httpx'],
         'httpx-speedups': ['ciso8601>=2.3.0', 'httpx'],


### PR DESCRIPTION
Exception caused by abandoned `cchardet` library:

`src/cchardet/_cchardet.cpp:196:12: fatal error: longintrepr.h: No such file or directory`

See also:
* https://github.com/PyYoshi/cChardet/issues/81
* https://github.com/PyYoshi/cChardet/issues/81#issuecomment-1329126634
