### PR TITLE
Update ClickHouse image for tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,8 @@ html_types:
 	cython -a aiochclient/_types.pyx
 
 docker-clickhouse:
-	docker pull yandex/clickhouse-server
-	docker start cs || docker run -p 8123:8123 -d --name cs yandex/clickhouse-server
+	docker pull clickhouse/clickhouse-server
+	docker start cs || docker run -p 8123:8123 -d --name cs clickhouse/clickhouse-server
 
 install-dev-requirements:
 	pip install twine


### PR DESCRIPTION
Since ClickHouse became a separate company all its images have also been stored separately on dockerhub.
And the image from Yandex stopped being updated.

So current `yandex/clickhouse-server` image have version 22.1.3.7.
Whereas `clickhouse/clickhouse-server` — 23.12.2.59 (latest)

P.S. And there is another reason to update — older version of ClickHouse didnt support `JSONEachRow format` for flatten Nested column and couple tests for this column are failed. 

For example query: 
```sql  
SELECT nested_int FROM all_types WHERE has(nested_int.value1, 0) format JSONEachRow" 
```
returns:

[22.1.3.7] `yandex/clickhouse-server`  
(incorrect)
``` json 
{"nested_int": [[0,1]]}
```

[23.12.2.59] `clickhouse/clickhouse-server`
**(correct)**
```json
{"nested_int": [{"value1": 0, "value2": 1}]}
```

I think that the image should be updated and  the most recent version of ClickHouse should be used for tests.