### PR TITLE
fix: need more than 1 value to unpack error when map is totally empty

### DIFF
--- a/aiochclient/_types.pyx
+++ b/aiochclient/_types.pyx
@@ -552,7 +552,10 @@ cdef class MapType:
         self.value_type = what_py_type(tps[comma_index + 1:], container=True)
 
     cdef dict _convert(self, str string):
-        key, value = string[1:-1].split(':', 1)
+        splits = string[1:-1].split(':', 1)
+        if len(splits) < 2:
+            return {}
+        key, value = splits
         return {
             self.key_type.p_type(decode(key.encode())): self.value_type.p_type(decode(value.encode()))
         }

--- a/aiochclient/types.py
+++ b/aiochclient/types.py
@@ -322,7 +322,10 @@ class MapType(BaseType):
         self.value_type = what_py_type(tps[comma_index + 1 :], container=True)
 
     def p_type(self, string: str) -> dict:
-        key, value = string[1:-1].split(':', 1)
+        splits = string[1:-1].split(':', 1)
+        if len(splits) < 2:
+            return {}
+        key, value = splits
         return {
             self.key_type.p_type(self.decode(key.encode())): self.value_type.p_type(
                 self.decode(value.encode())


### PR DESCRIPTION
When there is a map type column and you inserted an empty map into that column, then you read that row, it will cause exception of ValueError: need more than 1 value to unpack

That's because the returned string is '{}' and after split, it becomes [""], cannot be unpacked to key and value.

early return empty map fixes it.
 