### PR TITLE
Support EXPLAIN queries and subtypes on insert (#98, #97)

### DIFF
--- a/aiochclient/_types.pyx
+++ b/aiochclient/_types.pyx
@@ -847,7 +847,7 @@ cpdef what_py_converter(str name, bint container = False):
     return what_py_type(name, container).convert
 
 
-cdef bytes unconvert_str(str value):
+cdef bytes unconvert_str(object value):
     cdef:
         list res = ["'"]
         int i, sl = len(value)
@@ -884,17 +884,17 @@ cdef bytes unconvert_datetime(object value):
     return f"'{value}'".encode('latin-1')
 
 
-cdef bytes unconvert_tuple(tuple value):
+cdef bytes unconvert_tuple(object value):
     return b"(" + b",".join(py2ch(elem) for elem in value) + b")"
 
-cdef bytes unconvert_dict(dict value):
+cdef bytes unconvert_dict(object value):
     return (
         b"{" +
         b','.join(py2ch(key) + b':' + py2ch(val) for key, val in value.items()) +
         b"}"
     )
 
-cdef bytes unconvert_array(list value):
+cdef bytes unconvert_array(object value):
     return b"[" + b",".join(py2ch(elem) for elem in value) + b"]"
 
 
@@ -933,15 +933,24 @@ cdef dict PY_TYPES_MAPPING = {
 
 
 cpdef bytes py2ch(value):
-    try:
-        return PY_TYPES_MAPPING[type(value)](value)
-    except KeyError:
+    converter = PY_TYPES_MAPPING.get(type(value))
+    if converter is None:
+        # Fall back to the closest registered base type, walking the MRO so
+        # the most specific match wins (e.g. datetime before date). This lets
+        # subclasses of supported types — StrEnum/IntEnum, namedtuples, etc. —
+        # be inserted too.
+        for base in type(value).__mro__:
+            converter = PY_TYPES_MAPPING.get(base)
+            if converter is not None:
+                break
+    if converter is None:
         raise ChClientError(
             f"Unrecognized type: '{type(value)}'. "
-            f"The value type should be exactly one of "
-            f"int, float, str, dt.date, dt.datetime, dict, tuple, list, uuid.UUID (or None). "
-            f"No subclasses yet."
+            f"The value type should be one of "
+            f"int, float, str, dt.date, dt.datetime, dict, tuple, list, uuid.UUID "
+            f"(or a subclass of one of them, or None)."
         )
+    return converter(value)
 
 def rows2ch(*rows):
     return b",".join(unconvert_tuple(tuple(row)) for row in rows)

--- a/aiochclient/client.py
+++ b/aiochclient/client.py
@@ -469,7 +469,7 @@ class ChClient:
     def _parse_squery(query):
         statement = sqlparse.parse(query)[0]
         statement_type = statement.get_type()
-        if statement_type in ('SELECT', 'SHOW', 'DESCRIBE', 'EXISTS'):
+        if statement_type in ('SELECT', 'SHOW', 'DESCRIBE', 'EXISTS', 'EXPLAIN'):
             need_fetch = True
         else:
             need_fetch = False

--- a/aiochclient/sql.py
+++ b/aiochclient/sql.py
@@ -34,7 +34,7 @@ SQLPARSE_LEXER.clear()
 SQLPARSE_LEXER.set_SQL_REGEX(
     [
         (r'(FORMAT)\b', sqlparse.tokens.Keyword),
-        (r'(DESCRIBE|SHOW|EXISTS)\b', sqlparse.tokens.Keyword.DML),
+        (r'(DESCRIBE|SHOW|EXISTS|EXPLAIN)\b', sqlparse.tokens.Keyword.DML),
         *sqlparse.keywords.SQL_REGEX,
     ]
 )
@@ -48,5 +48,6 @@ SQLPARSE_LEXER.add_keywords(
         'EXISTS': tokens.Keyword.DML,
         'DESCRIBE': tokens.Keyword.DML,
         'SHOW': tokens.Keyword.DML,
+        'EXPLAIN': tokens.Keyword.DML,
     }
 )

--- a/aiochclient/types.py
+++ b/aiochclient/types.py
@@ -549,16 +549,24 @@ def what_py_converter(name: str, container: bool = False) -> Callable:
 
 
 def py2ch(value):
-    try:
-        return PY_TYPES_MAPPING[type(value)](value)
-    except KeyError:
+    converter = PY_TYPES_MAPPING.get(type(value))
+    if converter is None:
+        # Fall back to the closest registered base type, walking the MRO so
+        # the most specific match wins (e.g. datetime before date). This lets
+        # subclasses of supported types — StrEnum/IntEnum, namedtuples, etc. —
+        # be inserted too.
+        for base in type(value).__mro__:
+            converter = PY_TYPES_MAPPING.get(base)
+            if converter is not None:
+                break
+    if converter is None:
         raise ChClientError(
             f"Unrecognized type: '{type(value)}'. "
-            f"The value type should be exactly one of "
+            f"The value type should be one of "
             f"int, float, str, dt.date, dt.datetime, "
-            f"dict, tuple, list, uuid.UUID (or None). "
-            f"No subclasses yet."
+            f"dict, tuple, list, uuid.UUID (or a subclass of one of them, or None)."
         )
+    return converter(value)
 
 
 def rows2ch(*rows):

--- a/tests.py
+++ b/tests.py
@@ -2,6 +2,7 @@ import datetime as dt
 import json
 import os
 from decimal import Decimal
+from enum import Enum, IntEnum
 from ipaddress import IPv4Address, IPv6Address
 from uuid import uuid4
 
@@ -966,6 +967,26 @@ class TestTypes:
         assert await self.ch.fetchval("SELECT m FROM t_issue_117") == {}
         await self.ch.execute("DROP TABLE IF EXISTS t_issue_117")
 
+    async def test_insert_subtypes(self):
+        # https://github.com/maximdanilchenko/aiochclient/issues/97
+        # Subclasses of supported types (e.g. str/int Enums) must be accepted.
+        class Color(str, Enum):
+            RED = "red"
+
+        class Level(IntEnum):
+            HIGH = 5
+
+        await self.ch.execute("DROP TABLE IF EXISTS t_issue_97")
+        await self.ch.execute(
+            "CREATE TABLE t_issue_97 (s String, n UInt8) ENGINE = Memory"
+        )
+        await self.ch.execute("INSERT INTO t_issue_97 VALUES", (Color.RED, Level.HIGH))
+        assert await self.ch.fetchrow("SELECT s, n FROM t_issue_97") == {
+            "s": "red",
+            "n": 5,
+        }
+        await self.ch.execute("DROP TABLE IF EXISTS t_issue_97")
+
 
 @pytest.mark.fetching
 @pytest.mark.usefixtures("class_chclient")
@@ -1062,6 +1083,15 @@ class TestFetching:
     async def test_exists_table(self):
         exists = await self.ch.fetchrow("EXISTS TABLE all_types")
         assert exists == {'result': 1}
+
+    async def test_explain_with_fetch(self):
+        # https://github.com/maximdanilchenko/aiochclient/issues/98
+        rows = await self.ch.fetch("EXPLAIN SELECT 1")
+        assert rows
+        assert all(isinstance(row[0], str) for row in rows)
+
+        value = await self.ch.fetchval("EXPLAIN SYNTAX SELECT 1 + 1")
+        assert value == "SELECT 1 + 1"
 
     async def test_quoted_string(self):
         record = await self.ch.fetchrow("SELECT 'foo\\'bar' AS quoted_string")


### PR DESCRIPTION
Support EXPLAIN queries and subtypes on insert

Closes #98
Closes #97

#98: EXPLAIN queries returned no rows because the statement type was not recognized as a fetch query. Register EXPLAIN as a DML keyword in the sqlparse lexer patch and treat it like SELECT/SHOW/DESCRIBE/EXISTS, so the plan is fetched (a FORMAT clause is appended like for other selects).

#97: py2ch matched only on the exact type(value), rejecting subclasses of supported types (e.g. str/int Enums such as StrEnum/IntEnum, namedtuples). It now falls back to the closest registered base type by walking the MRO, so the most specific match wins (e.g. datetime before date). The Cython unconvert_str/tuple/array/dict signatures are relaxed from strict builtin types to object so subclass instances pass through and their real data is read (matching the pure-Python path) instead of being rejected at the call boundary.

Applied to both types.py and _types.pyx. Added regression tests. Full suite: 394 passed on both the Cython and pure-Python paths.