### PR TITLE
Fix documentation build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 .pypirc
 .pytest_cache
 /docs/build
+/docs/_build
 /build
 *.egg-info
 /dist

--- a/aiochclient/client.py
+++ b/aiochclient/client.py
@@ -53,7 +53,7 @@ class ChClient:
         Pass True if you want Clickhouse to compress its responses with gzip.
         They will be decompressed automatically. But overall it will be slightly slower.
 
-    :param **settings:
+    :param \\*\\*settings:
         Any settings from https://clickhouse.yandex/docs/en/operations/settings
     """
 
@@ -430,7 +430,8 @@ class ChClient:
         Usage:
 
         .. code-block:: python
-            with open('data.csv', 'rb') as f: 
+
+            with open('data.csv', 'rb') as f:
                 await client.insert_file(
                     "INSERT INTO t FORMAT CSV",
                     f.read(),

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,15 +14,5 @@ source_suffix = ".rst"
 master_doc = "index"
 pygments_style = "default"
 html_theme = "sphinx_rtd_theme"
-html_static_path = ["_static"]
-
-html_theme_options = {
-    "description": (
-        "Async http(s) clickhouse client for python 3.10+ "
-        "with types converting and streaming support"
-    ),
-    "show_powered_by": False,
-    "display_version": True,
-}
 html_title = "aiochclient Documentation"
 html_short_title = "aiochclient"

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -53,11 +53,12 @@ and check ClickHouse is alive. Here's how you would do that:
 This automatically queries a instance of ClickHouse on `localhost:8123` with the
 default user. You may want to set up a different connection to test. To do that,
 change the following line::
+
     client = ChClient(s)
 
 To something like::
 
     client = ChClient(s, url='http://localhost:8123')
 
-You can find more options for connecting to ClickHouse in the :ref:`api`.
+You can find more options for connecting to ClickHouse in the :ref:`reference`.
 Continue reading to learn more about `aiochclient`.

--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -4,6 +4,10 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.11"
+
+sphinx:
+  configuration: docs/conf.py
+
 python:
   install:
     - requirements: dev-requirements/dev-requirements.txt


### PR DESCRIPTION
Read the Docs now requires the sphinx.configuration key; without it the build failed with "Missing Sphinx configuration key". Point it at docs/conf.py.