### PR TITLE
Handle DateTime64 sub-second precision consistently (#91, #127, #119)

### DIFF
--- a/aiochclient/_types.pyx
+++ b/aiochclient/_types.pyx
@@ -26,7 +26,17 @@ cdef datetime _datetime_parse(str string):
     return datetime.strptime(string, '%Y-%m-%d %H:%M:%S')
 
 cdef datetime _datetime_parse_f(str string):
-    return datetime.strptime(string, '%Y-%m-%d %H:%M:%S.%f')
+    # ClickHouse DateTime64 may carry up to 9 fractional digits (nanoseconds),
+    # but Python datetime only supports microseconds and strptime's "%f"
+    # rejects more than 6 digits. Truncate the fractional part to microseconds
+    # so DateTime64(7..9) parses — matching ciso8601 when it is installed.
+    cdef:
+        Py_ssize_t dot = string.find('.')
+        datetime parsed
+    if dot < 0:
+        return datetime.strptime(string, '%Y-%m-%d %H:%M:%S')
+    parsed = datetime.strptime(string[:dot], '%Y-%m-%d %H:%M:%S')
+    return parsed.replace(microsecond=int(string[dot + 1:dot + 7].ljust(6, '0')))
 
 cdef date _date_parse(str string):
     return datetime.strptime(string, '%Y-%m-%d')

--- a/aiochclient/types.py
+++ b/aiochclient/types.py
@@ -21,7 +21,16 @@ except ImportError:
         return dt.datetime.strptime(string, '%Y-%m-%d %H:%M:%S')
 
     def datetime_parse_f(string):
-        return dt.datetime.strptime(string, '%Y-%m-%d %H:%M:%S.%f')
+        # ClickHouse DateTime64 may carry up to 9 fractional digits
+        # (nanoseconds), but Python datetime only supports microseconds and
+        # strptime's "%f" rejects more than 6 digits. Truncate the fractional
+        # part to microseconds so DateTime64(7..9) parses — matching the
+        # behaviour of ciso8601 when it is installed.
+        head, _, frac = string.partition('.')
+        parsed = dt.datetime.strptime(head, '%Y-%m-%d %H:%M:%S')
+        if frac:
+            parsed = parsed.replace(microsecond=int(frac[:6].ljust(6, '0')))
+        return parsed
 
 
 __all__ = ["what_py_converter", "rows2ch", "json2ch", "py2ch", "empty_convertor"]

--- a/tests.py
+++ b/tests.py
@@ -905,6 +905,51 @@ class TestTypes:
         assert record[0] == result, record
         assert record["datetime64"] == result, record
 
+    async def test_datetime64_nanoseconds(self):
+        # https://github.com/maximdanilchenko/aiochclient/issues/91
+        # https://github.com/maximdanilchenko/aiochclient/issues/127
+        # DateTime64(9) carries nanoseconds, but Python datetime only supports
+        # microseconds — the fractional part is truncated to 6 digits, and
+        # consistently so with or without ciso8601 installed.
+        await self.ch.execute("DROP TABLE IF EXISTS dt64_ns")
+        await self.ch.execute("CREATE TABLE dt64_ns (d DateTime64(9)) ENGINE = Memory")
+        await self.ch.execute(
+            "INSERT INTO dt64_ns VALUES ('2024-06-24 19:42:52.123456789')"
+        )
+        assert await self.ch.fetchval("SELECT d FROM dt64_ns") == dt.datetime(
+            2024, 6, 24, 19, 42, 52, 123456
+        )
+        await self.ch.execute("DROP TABLE IF EXISTS dt64_ns")
+
+    async def test_insert_datetime_with_microseconds(self):
+        # https://github.com/maximdanilchenko/aiochclient/issues/119
+        # A datetime carrying microseconds inserts into a DateTime column (the
+        # server truncates to second precision) ...
+        await self.ch.execute("DROP TABLE IF EXISTS dt_micro")
+        await self.ch.execute("CREATE TABLE dt_micro (d DateTime) ENGINE = Memory")
+        await self.ch.execute(
+            "INSERT INTO dt_micro VALUES",
+            (dt.datetime(2024, 6, 24, 19, 42, 52, 607030),),
+        )
+        assert await self.ch.fetchval("SELECT d FROM dt_micro") == dt.datetime(
+            2024, 6, 24, 19, 42, 52
+        )
+        # ... and the same value keeps its sub-second part in a DateTime64
+        # column — which is why the client always sends the microseconds.
+        await self.ch.execute("DROP TABLE IF EXISTS dt64_micro")
+        await self.ch.execute(
+            "CREATE TABLE dt64_micro (d DateTime64(6)) ENGINE = Memory"
+        )
+        await self.ch.execute(
+            "INSERT INTO dt64_micro VALUES",
+            (dt.datetime(2024, 6, 24, 19, 42, 52, 607030),),
+        )
+        assert await self.ch.fetchval("SELECT d FROM dt64_micro") == dt.datetime(
+            2024, 6, 24, 19, 42, 52, 607030
+        )
+        await self.ch.execute("DROP TABLE IF EXISTS dt_micro")
+        await self.ch.execute("DROP TABLE IF EXISTS dt64_micro")
+
     async def test_named_tuples(self):
         """Named tuples are used for example in geohash functions
 


### PR DESCRIPTION
Consistent DateTime64 sub-second handling

Closes #91
Closes #127
Closes #119