### PR TITLE
Actualize README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ Or `aiochclient[httpx-speedups]` to install with extra speedups.
 
 Installing with `[*-speedups]` adds the following:
 
-- [cChardet](https://pypi.python.org/pypi/cchardet) for `aiohttp` speedup
-- [aiodns](https://pypi.python.org/pypi/aiodns) for `aiohttp` speedup
+- [faust-cchardet](https://pypi.org/project/faust-cchardet/) for `aiohttp` speedup
+- [aiodns](https://pypi.org/project/aiodns/) for `aiohttp` speedup
 - [ciso8601](https://github.com/closeio/ciso8601) for ultra-fast datetime
   parsing while decoding data from ClickHouse for `aiohttp` and `httpx`.
 

--- a/aiochclient/client.py
+++ b/aiochclient/client.py
@@ -54,7 +54,7 @@ class ChClient:
         They will be decompressed automatically. But overall it will be slightly slower.
 
     :param \\*\\*settings:
-        Any settings from https://clickhouse.yandex/docs/en/operations/settings
+        Any settings from https://clickhouse.com/docs/en/operations/settings/settings
     """
 
     __slots__ = ("_session", "url", "params", "headers", "_json", "_http_client")

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -50,7 +50,7 @@ and check ClickHouse is alive. Here's how you would do that:
     if __name__ == '__main__':
         asyncio.run(main())
 
-This automatically queries a instance of ClickHouse on `localhost:8123` with the
+This automatically queries an instance of ClickHouse on `localhost:8123` with the
 default user. You may want to set up a different connection to test. To do that,
 change the following line::
 


### PR DESCRIPTION
- README: the aiohttp speedup extra is faust-cchardet, not the unmaintained cchardet (matches setup.py); refresh the PyPI links.
- client docstring: update the settings link from the retired clickhouse.yandex domain to clickhouse.com.
- docs: fix "a instance" -> "an instance".