### PR TITLE
Raise ChClientError on mid-stream ClickHouse exceptions (#93)

### DIFF
--- a/aiochclient/http_clients/abc.py
+++ b/aiochclient/http_clients/abc.py
@@ -1,7 +1,35 @@
 from abc import ABC, abstractmethod
-from typing import Any, AsyncGenerator
+from typing import Any, AsyncGenerator, List, Optional
 
 from aiochclient.exceptions import ChClientError
+
+# ClickHouse commits an HTTP 200 once it starts streaming a large result, so an
+# error that happens afterwards cannot change the status code. It is instead
+# reported through the ``X-ClickHouse-Exception-Code`` trailing header and, on
+# recent servers, an ``__exception__`` envelope appended to the response body.
+# See https://github.com/maximdanilchenko/aiochclient/issues/93
+EXCEPTION_CODE_HEADER = 'X-ClickHouse-Exception-Code'
+EXCEPTION_MARKER = b'__exception__'
+
+
+def raise_if_exception_code(
+    exception_code: Optional[str], exception_lines: List[bytes]
+) -> None:
+    """Raise ``ChClientError`` if ClickHouse reported a mid-stream exception.
+
+    ``exception_code`` is the value of the ``X-ClickHouse-Exception-Code``
+    response/trailer header (``None`` when the query succeeded).
+    ``exception_lines`` are the body lines collected from the ``__exception__``
+    envelope, used to build a helpful message when the server provides it.
+    """
+    if exception_code is None:
+        return
+    text = ' '.join(
+        line.decode(errors='replace').strip()
+        for line in exception_lines
+        if line.startswith(b'Code:') or b'Exception' in line
+    ).strip()
+    raise ChClientError(text or f"ClickHouse returned exception code {exception_code}")
 
 
 class HttpClientABC(ABC):

--- a/aiochclient/http_clients/aiohttp.py
+++ b/aiochclient/http_clients/aiohttp.py
@@ -3,7 +3,12 @@ from typing import Any, AsyncGenerator, List, Optional
 from aiohttp import ClientSession
 
 from aiochclient.exceptions import ChClientError
-from aiochclient.http_clients.abc import HttpClientABC
+from aiochclient.http_clients.abc import (
+    EXCEPTION_CODE_HEADER,
+    EXCEPTION_MARKER,
+    HttpClientABC,
+    raise_if_exception_code,
+)
 
 
 class AiohttpHttpClient(HttpClientABC):
@@ -28,13 +33,24 @@ class AiohttpHttpClient(HttpClientABC):
             await _check_response(resp)
 
             buffer: bytes = b''
+            exception_lines: List[bytes] = []
+            in_exception = False
             async for chunk in resp.content.iter_any():
                 lines: List[bytes] = chunk.split(self.line_separator)
                 if buffer:
                     lines[0] = buffer + lines[0]
                 for line in lines[:-1]:
-                    yield line + self.line_separator
+                    if line == EXCEPTION_MARKER:
+                        in_exception = True
+                    if in_exception:
+                        exception_lines.append(line)
+                    else:
+                        yield line + self.line_separator
                 buffer = lines[-1]
+            # Trailers are available now that the body is fully consumed.
+            raise_if_exception_code(
+                resp.headers.get(EXCEPTION_CODE_HEADER), exception_lines
+            )
             assert not buffer
 
     async def post_no_return(
@@ -44,6 +60,11 @@ class AiohttpHttpClient(HttpClientABC):
             url=url, params=params, headers=headers, data=data
         ) as resp:
             await _check_response(resp)
+            body = await resp.read()
+            raise_if_exception_code(
+                resp.headers.get(EXCEPTION_CODE_HEADER),
+                body.split(self.line_separator),
+            )
 
     async def close(self) -> None:
         await self._session.close()

--- a/aiochclient/http_clients/httpx.py
+++ b/aiochclient/http_clients/httpx.py
@@ -3,7 +3,12 @@ from typing import Any, AsyncGenerator, List, Optional
 from httpx import AsyncClient, Response
 
 from aiochclient.exceptions import ChClientError
-from aiochclient.http_clients.abc import HttpClientABC
+from aiochclient.http_clients.abc import (
+    EXCEPTION_CODE_HEADER,
+    EXCEPTION_MARKER,
+    HttpClientABC,
+    raise_if_exception_code,
+)
 
 
 class HttpxHttpClient(HttpClientABC):
@@ -28,13 +33,24 @@ class HttpxHttpClient(HttpClientABC):
         await _check_response(resp)
 
         buffer: bytes = b''
+        exception_lines: List[bytes] = []
+        in_exception = False
         async for chunk in resp.aiter_bytes():
             lines: List[bytes] = chunk.split(self.line_separator)
             if buffer:
                 lines[0] = buffer + lines[0]
             for line in lines[:-1]:
-                yield line + self.line_separator
+                if line == EXCEPTION_MARKER:
+                    in_exception = True
+                if in_exception:
+                    exception_lines.append(line)
+                else:
+                    yield line + self.line_separator
             buffer = lines[-1]
+        # Trailers are available now that the body is fully consumed.
+        raise_if_exception_code(
+            resp.headers.get(EXCEPTION_CODE_HEADER), exception_lines
+        )
         assert not buffer
 
     async def post_no_return(
@@ -44,6 +60,10 @@ class HttpxHttpClient(HttpClientABC):
             url=url, params=params, headers=headers, content=data
         )
         await _check_response(resp)
+        raise_if_exception_code(
+            resp.headers.get(EXCEPTION_CODE_HEADER),
+            (await resp.aread()).split(self.line_separator),
+        )
 
     async def close(self) -> None:
         await self._session.aclose()

--- a/tests.py
+++ b/tests.py
@@ -1430,3 +1430,125 @@ class TestErrorBody:
             await httpx_client._check_response(_FakeResp())
         assert str(exc.value).strip()
         assert "502" in str(exc.value)
+
+
+class TestExceptionTrailer:
+    # https://github.com/maximdanilchenko/aiochclient/issues/93
+    # ClickHouse commits a 200 status before streaming a large result, so a
+    # mid-stream error is reported via the X-ClickHouse-Exception-Code trailer
+    # and an __exception__ envelope appended to the body, not the status code.
+    OK_BODY = b"a\nString\nx\ny\n"
+    ERR_BODY = (
+        b"a\nString\nx\n"
+        b"__exception__\ntag\n"
+        b"Code: 159. DB::Exception: Timeout exceeded. (TIMEOUT_EXCEEDED)\n"
+        b"__exception__\n"
+    )
+    ERR_HEADERS = {"X-ClickHouse-Exception-Code": "159"}
+
+    async def test_raise_if_exception_code_helper(self):
+        from aiochclient.http_clients import abc
+
+        # no code -> no error
+        abc.raise_if_exception_code(None, [])
+        # code present -> ChClientError carrying the server message
+        with pytest.raises(ChClientError) as exc:
+            abc.raise_if_exception_code(
+                "159",
+                [
+                    b"__exception__",
+                    b"Code: 159. DB::Exception: Timeout. (TIMEOUT_EXCEEDED)",
+                ],
+            )
+        assert "TIMEOUT_EXCEEDED" in str(exc.value)
+        # code present but no envelope text -> falls back to the code
+        with pytest.raises(ChClientError) as exc:
+            abc.raise_if_exception_code("241", [])
+        assert "241" in str(exc.value)
+
+    async def _collect(self, client):
+        return [line async for line in client.post_return_lines("url", {}, {}, b"")]
+
+    async def test_aiohttp_trailer_stops_stream(self):
+        from aiochclient.http_clients.aiohttp import AiohttpHttpClient
+
+        # success: all data lines yielded, no error
+        client = AiohttpHttpClient(_FakeAioSession(200, {}, self.OK_BODY))
+        assert await self._collect(client) == [b"a\n", b"String\n", b"x\n", b"y\n"]
+
+        # mid-stream exception: data yielded, envelope skipped, error raised
+        client = AiohttpHttpClient(
+            _FakeAioSession(200, self.ERR_HEADERS, self.ERR_BODY)
+        )
+        with pytest.raises(ChClientError) as exc:
+            await self._collect(client)
+        assert "TIMEOUT_EXCEEDED" in str(exc.value)
+
+    async def test_httpx_trailer_stops_stream(self):
+        from aiochclient.http_clients.httpx import HttpxHttpClient
+
+        client = HttpxHttpClient(_FakeHttpxSession(200, {}, self.OK_BODY))
+        assert await self._collect(client) == [b"a\n", b"String\n", b"x\n", b"y\n"]
+
+        client = HttpxHttpClient(
+            _FakeHttpxSession(200, self.ERR_HEADERS, self.ERR_BODY)
+        )
+        with pytest.raises(ChClientError) as exc:
+            await self._collect(client)
+        assert "TIMEOUT_EXCEEDED" in str(exc.value)
+
+
+class _FakeAioResp:
+    def __init__(self, status, headers, body):
+        self.status = status
+        self.headers = headers
+        self._body = body
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    class _Content:
+        def __init__(self, body):
+            self._body = body
+
+        async def iter_any(self):
+            yield self._body
+
+    @property
+    def content(self):
+        return self._Content(self._body)
+
+    async def read(self):
+        return self._body
+
+
+class _FakeAioSession:
+    def __init__(self, status, headers, body):
+        self._resp = _FakeAioResp(status, headers, body)
+
+    def post(self, **kwargs):
+        return self._resp
+
+
+class _FakeHttpxResp:
+    def __init__(self, status, headers, body):
+        self.status_code = status
+        self.headers = headers
+        self._body = body
+
+    async def aiter_bytes(self):
+        yield self._body
+
+    async def aread(self):
+        return self._body
+
+
+class _FakeHttpxSession:
+    def __init__(self, status, headers, body):
+        self._resp = _FakeHttpxResp(status, headers, body)
+
+    async def post(self, **kwargs):
+        return self._resp


### PR DESCRIPTION
When a query exceeds max_execution_time (or fails for any reason) after ClickHouse has already committed an HTTP 200 and started streaming a large result, the error is reported through the X-ClickHouse-Exception-Code trailing header and an __exception__ envelope appended to the body, not the status code. The client then tried to parse that trailing exception text as data and crashed with an unhandled IndexError / JSONDecodeError.

Both backends now, after the body is fully consumed, check the X-ClickHouse-Exception-Code header (available as a trailer at that point) and raise a ChClientError carrying the server's message. The __exception__ envelope is recognized while streaming and not yielded as data, so the JSON path doesn't choke on it before the check. The same check is applied to the no-return (INSERT/DDL) path. Smaller error responses already arrive with a non-200 status and keep being handled by _check_response.

Added unit tests (fake responses) for the trailer/envelope handling on both backends and for the shared helper, since a true 200-then-trailer response is hard to provoke from a modern server that usually returns a proper status.