### PR TITLE
RowBinary INSERT (write path) - #134, phase 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,17 +149,18 @@ assert list(row.values()) == [1, (dt.date(2018, 9, 8), 3.14)]
 
 ### RowBinary engine (experimental)
 
-By default SELECT results are decoded from ClickHouse's text (TSV) format. You
-can instead decode them with the binary `RowBinary` engine, which avoids text
-escaping entirely and is typically faster:
+By default results are encoded/decoded through ClickHouse's text (TSV) format.
+You can instead use the binary `RowBinary` engine, which avoids text escaping
+entirely and is typically faster, for both SELECT and INSERT:
 
 ```python
 client = ChClient(session, binary=True)
+await client.execute("INSERT INTO t VALUES", (1, "a"), (2, "b"))
 rows = await client.fetch("SELECT * FROM t")
 ```
 
-`binary=True` currently affects the SELECT/decoding path only (INSERTs are
-unchanged).
+Because RowBinary encoding is type-specific, a binary INSERT first looks up the
+target column types (one lightweight query) and encodes the rows to match them.
 
 ## Documentation
 

--- a/aiochclient/binary.py
+++ b/aiochclient/binary.py
@@ -98,12 +98,33 @@ class BinaryReader:
             return result
 
 
-async def parse_header(reader: BinaryReader) -> "RowBinaryFabric":
-    """Read the RowBinaryWithNamesAndTypes header and build a record fabric."""
+async def _read_header(reader: BinaryReader):
+    """Read a RowBinaryWithNamesAndTypes header -> (names, type strings)."""
     num_columns = await reader.parse(Cursor.read_varint)
     names = [(await reader.parse(read_binary_str)).decode() for _ in range(num_columns)]
     types = [(await reader.parse(read_binary_str)).decode() for _ in range(num_columns)]
+    return names, types
+
+
+async def parse_header(reader: BinaryReader) -> "RowBinaryFabric":
+    """Read the RowBinaryWithNamesAndTypes header and build a record fabric."""
+    names, types = await _read_header(reader)
     return RowBinaryFabric(names, types)
+
+
+async def fetch_column_types(source: AsyncGenerator[bytes, None]) -> list:
+    """Read just the header of a (LIMIT 0) RowBinaryWithNamesAndTypes response
+    and return the column type objects, used to encode INSERT rows."""
+    reader = BinaryReader(source)
+    _, types = await _read_header(reader)
+    return [what_py_type(tp) for tp in types]
+
+
+def rows_to_binary(rows, types: list) -> bytes:
+    """Encode rows (iterables of column values) as a RowBinary body."""
+    return b"".join(
+        b"".join(tp.write(value) for tp, value in zip(types, row)) for row in rows
+    )
 
 
 class RowBinaryFabric:

--- a/aiochclient/client.py
+++ b/aiochclient/client.py
@@ -1,10 +1,11 @@
 import json as json_
+import re
 import warnings
 from enum import Enum
 from types import TracebackType
 from typing import Any, AsyncGenerator, BinaryIO, Dict, List, Optional, Type
 
-from aiochclient.binary import rows_from_binary
+from aiochclient.binary import fetch_column_types, rows_from_binary, rows_to_binary
 from aiochclient.exceptions import ChClientError
 from aiochclient.http_clients.abc import HttpClientABC
 from aiochclient.records import FromJsonFabric, Record, RecordsFabric
@@ -174,12 +175,18 @@ class ChClient:
                 raise ChClientError(
                     "It is possible to pass arguments only for INSERT queries"
                 )
-            params = {**self.params, "query": query}
 
-            if is_json:
+            if self._binary and not is_json:
+                # RowBinary is type-specific, so fetch the target column types
+                # and encode the rows to match them exactly.
+                types = await self._fetch_insert_column_types(query)
+                query = self._rowbinary_insert_query(query)
+                data = rows_to_binary(args, types)
+            elif is_json:
                 data = json2ch(*args, dumps=self._json.dumps)
             else:
                 data = rows2ch(*args)
+            params = {**self.params, "query": query}
         else:
             params = {**self.params}
             data = query.encode()
@@ -214,6 +221,36 @@ class ChClient:
             await self._http_client.post_no_return(
                 url=self.url, params=params, headers=self.headers, data=data
             )
+
+    @staticmethod
+    def _rowbinary_insert_query(query: str) -> str:
+        # Swap the trailing ``VALUES`` for ``FORMAT RowBinary`` so the binary
+        # body is parsed as RowBinary rather than VALUES tuples.
+        head = re.sub(r"\s+VALUES\b.*$", "", query, flags=re.IGNORECASE | re.DOTALL)
+        return head.rstrip() + " FORMAT RowBinary"
+
+    async def _fetch_insert_column_types(self, query: str) -> list:
+        # RowBinary encoding depends on the exact column types, so look them up
+        # from the target table (in the order the INSERT lists them).
+        match = re.match(
+            r"\s*INSERT\s+INTO\s+(?P<table>[^\s(]+)\s*(?:\((?P<cols>[^)]*)\))?",
+            query,
+            re.IGNORECASE,
+        )
+        if not match:
+            raise ChClientError("Could not parse the INSERT target for binary mode")
+        cols = match.group("cols")
+        probe = (
+            f"SELECT {cols.strip() if cols else '*'} "
+            f"FROM {match.group('table')} LIMIT 0 FORMAT RowBinaryWithNamesAndTypes"
+        )
+        source = self._http_client.post_return_bytes(
+            url=self.url,
+            params={**self.params},
+            headers=self.headers,
+            data=probe.encode(),
+        )
+        return await fetch_column_types(source)
 
     async def execute(
         self,

--- a/aiochclient/types.py
+++ b/aiochclient/types.py
@@ -45,6 +45,19 @@ RB_INT_SPECS = {
 RB_EPOCH_DATE = dt.date(1970, 1, 1)
 RB_EPOCH_DATETIME = dt.datetime(1970, 1, 1)
 
+
+def write_varint(value: int) -> bytes:
+    """Encode an unsigned integer as LEB128 (RowBinary length prefix)."""
+    out = bytearray()
+    while True:
+        byte = value & 0x7F
+        value >>= 7
+        if value:
+            out.append(byte | 0x80)
+        else:
+            out.append(byte)
+            return bytes(out)
+
 try:
     import ciso8601
 
@@ -192,6 +205,12 @@ class BaseType(ABC):
             f"RowBinary decoding is not implemented for type '{self.name}'"
         )
 
+    def write(self, value) -> bytes:
+        """Encode a single value to RowBinary bytes (binary engine)."""
+        raise ChClientError(
+            f"RowBinary encoding is not implemented for type '{self.name}'"
+        )
+
     @staticmethod
     def unconvert(value) -> bytes:
         return b"%a" % value
@@ -218,6 +237,13 @@ class StrType(BaseType):
             length = cursor.read_varint()
         return cursor.read(length).decode()
 
+    def write(self, value: str) -> bytes:
+        data = value.encode()
+        if self.name.startswith("FixedString"):
+            length = int(self.name[12:-1])
+            return data[:length].ljust(length, b"\x00")
+        return write_varint(len(data)) + data
+
     @staticmethod
     def unconvert(value: str) -> bytes:
         value = value.replace("\\", "\\\\").replace("'", "\\'")
@@ -239,6 +265,9 @@ class BoolType(BaseType):
     def read(self, cursor) -> bool:
         return cursor.read(1) != b"\x00"
 
+    def write(self, value: bool) -> bytes:
+        return b"\x01" if value else b"\x00"
+
     @staticmethod
     def unconvert(value: bool) -> bytes:
         # We use an integer representation here to be compatible with older
@@ -256,6 +285,10 @@ class IntType(BaseType):
         size, signed = RB_INT_SPECS[self.name]
         return int.from_bytes(cursor.read(size), "little", signed=signed)
 
+    def write(self, value: int) -> bytes:
+        size, signed = RB_INT_SPECS[self.name]
+        return int(value).to_bytes(size, "little", signed=signed)
+
     @staticmethod
     def unconvert(value: int) -> bytes:
         return b"%d" % value
@@ -268,6 +301,11 @@ class FloatType(IntType):
         if self.name == "Float64":
             return struct.unpack("<d", cursor.read(8))[0]
         return struct.unpack("<f", cursor.read(4))[0]
+
+    def write(self, value: float) -> bytes:
+        if self.name == "Float64":
+            return struct.pack("<d", value)
+        return struct.pack("<f", value)
 
     @staticmethod
     def unconvert(value: float) -> bytes:
@@ -292,6 +330,9 @@ class DateType(BaseType):
         return RB_EPOCH_DATE + dt.timedelta(
             days=int.from_bytes(cursor.read(2), "little")
         )
+
+    def write(self, value: dt.date) -> bytes:
+        return (value - RB_EPOCH_DATE).days.to_bytes(2, "little")
 
     @staticmethod
     def unconvert(value: dt.date) -> bytes:
@@ -332,6 +373,15 @@ class DateTimeType(BaseType):
             return RB_EPOCH_DATETIME + dt.timedelta(seconds=seconds)
         # Match the server's TSV output: wall-clock in the column timezone.
         return dt.datetime.fromtimestamp(seconds, zone).replace(tzinfo=None)
+
+    def write(self, value: dt.datetime) -> bytes:
+        zone = self._zone()
+        if zone is None:
+            seconds = (value - RB_EPOCH_DATETIME) // dt.timedelta(seconds=1)
+        else:
+            # ``value`` is naive wall-clock in the column timezone.
+            seconds = int(value.replace(tzinfo=zone).timestamp())
+        return seconds.to_bytes(4, "little")
 
     @staticmethod
     def unconvert(value: dt.datetime) -> bytes:
@@ -387,6 +437,21 @@ class DateTime64Type(BaseType):
             .replace(tzinfo=None)
         )
 
+    def write(self, value: dt.datetime) -> bytes:
+        zone = self._zone()
+        if zone is None:
+            micros = (value - RB_EPOCH_DATETIME) // dt.timedelta(microseconds=1)
+        else:
+            aware = value.replace(tzinfo=zone)
+            micros = (
+                aware - dt.datetime(1970, 1, 1, tzinfo=dt.timezone.utc)
+            ) // dt.timedelta(microseconds=1)
+        if self._precision <= 6:
+            ticks = micros // 10 ** (6 - self._precision)
+        else:
+            ticks = micros * 10 ** (self._precision - 6)
+        return ticks.to_bytes(8, "little", signed=True)
+
 
 class UUIDType(BaseType):
     def p_type(self, string):
@@ -403,6 +468,14 @@ class UUIDType(BaseType):
             | int.from_bytes(data[8:], "little")
         )
 
+    def write(self, value: UUID) -> bytes:
+        if not isinstance(value, UUID):
+            value = UUID(str(value))
+        number = value.int
+        return (number >> 64).to_bytes(8, "little") + (
+            number & 0xFFFFFFFFFFFFFFFF
+        ).to_bytes(8, "little")
+
     @staticmethod
     def unconvert(value: UUID) -> bytes:
         return b"%a" % str(value)
@@ -418,6 +491,9 @@ class IPv4Type(BaseType):
     def read(self, cursor) -> IPv4Address:
         return IPv4Address(int.from_bytes(cursor.read(4), "little"))
 
+    def write(self, value) -> bytes:
+        return int(IPv4Address(value)).to_bytes(4, "little")
+
     @staticmethod
     def unconvert(value: UUID) -> bytes:
         return b"%a" % str(value)
@@ -432,6 +508,9 @@ class IPv6Type(BaseType):
 
     def read(self, cursor) -> IPv6Address:
         return IPv6Address(cursor.read(16))
+
+    def write(self, value) -> bytes:
+        return IPv6Address(value).packed
 
     @staticmethod
     def unconvert(value: UUID) -> bytes:
@@ -459,6 +538,9 @@ class TupleType(BaseType):
 
     def read(self, cursor) -> tuple:
         return tuple(tp.read(cursor) for tp in self.types)
+
+    def write(self, value) -> bytes:
+        return b"".join(tp.write(elem) for tp, elem in zip(self.types, value))
 
     @staticmethod
     def unconvert(value) -> bytes:
@@ -510,6 +592,13 @@ class MapType(BaseType):
             for _ in range(cursor.read_varint())
         }
 
+    def write(self, value) -> bytes:
+        parts = [write_varint(len(value))]
+        for key, val in value.items():
+            parts.append(self.key_type.write(key))
+            parts.append(self.value_type.write(val))
+        return b"".join(parts)
+
     @staticmethod
     def unconvert(value) -> bytes:
         return (
@@ -537,6 +626,11 @@ class ArrayType(BaseType):
 
     def read(self, cursor) -> list:
         return [self.type.read(cursor) for _ in range(cursor.read_varint())]
+
+    def write(self, value) -> bytes:
+        return write_varint(len(value)) + b"".join(
+            self.type.write(elem) for elem in value
+        )
 
     @staticmethod
     def unconvert(value) -> bytes:
@@ -572,6 +666,13 @@ class NestedType(BaseType):
             for _ in range(cursor.read_varint())
         ]
 
+    def write(self, value) -> bytes:
+        parts = [write_varint(len(value))]
+        for row in value:
+            for tp, elem in zip(self.types, row):
+                parts.append(tp.write(elem))
+        return b"".join(parts)
+
     @staticmethod
     def unconvert(value) -> bytes:
         return (
@@ -600,6 +701,11 @@ class NullableType(BaseType):
         if cursor.read(1) != b"\x00":
             return None
         return self.type.read(cursor)
+
+    def write(self, value) -> bytes:
+        if value is None:
+            return b"\x01"
+        return b"\x00" + self.type.write(value)
 
     @staticmethod
     def unconvert(value) -> bytes:
@@ -630,6 +736,9 @@ class LowCardinalityType(BaseType):
         # In RowBinary a LowCardinality(T) is encoded exactly as T.
         return self.type.read(cursor)
 
+    def write(self, value) -> bytes:
+        return self.type.write(value)
+
 
 class EnumType(StrType):
     """Enum8/Enum16. TSV gives the label string (handled by StrType); RowBinary
@@ -644,10 +753,14 @@ class EnumType(StrType):
                 r"'((?:[^'\\]|\\.)*)'\s*=\s*(-?\d+)", name
             )
         }
+        self._reverse = {label: index for index, label in self._mapping.items()}
 
     def read(self, cursor) -> str:
         index = int.from_bytes(cursor.read(self._size), "little", signed=True)
         return self._mapping[index]
+
+    def write(self, value: str) -> bytes:
+        return self._reverse[value].to_bytes(self._size, "little", signed=True)
 
 
 class DecimalType(BaseType):
@@ -678,6 +791,10 @@ class DecimalType(BaseType):
     def read(self, cursor) -> Decimal:
         raw = int.from_bytes(cursor.read(self._size), "little", signed=True)
         return Decimal(raw).scaleb(-self._scale)
+
+    def write(self, value: Decimal) -> bytes:
+        raw = int(Decimal(value).scaleb(self._scale))
+        return raw.to_bytes(self._size, "little", signed=True)
 
     @staticmethod
     def unconvert(value: Decimal) -> bytes:

--- a/tests.py
+++ b/tests.py
@@ -1452,6 +1452,16 @@ class TestRowBinaryDecode:
             assert value == expected, type_name
             assert type(value) is type(expected), type_name
 
+    async def test_golden_encode(self):
+        from aiochclient.types import what_py_type
+
+        for type_name, hex_bytes, value in self.GOLDEN:
+            # DateTime64(9) nanoseconds are truncated to microseconds on read,
+            # so that one value is not byte-for-byte round-trippable.
+            if "DateTime64(9)" in type_name:
+                continue
+            assert what_py_type(type_name).write(value).hex() == hex_bytes, type_name
+
     async def test_varint_boundaries(self):
         from aiochclient.binary import Cursor
 
@@ -1522,6 +1532,61 @@ class TestRowBinary:
         # unambiguous (unlike the TSV path, issue #14).
         binary = self._binary_client()
         assert (await binary.fetchrow("SELECT '' AS s"))["s"] == ""
+
+    async def test_insert_round_trip(self):
+        binary = self._binary_client()
+        await binary.execute("DROP TABLE IF EXISTS rb_insert")
+        await binary.execute(
+            """
+            CREATE TABLE rb_insert (
+                u8 UInt8, i64 Int64, f Float64, s String, fs FixedString(4),
+                d Date, dttm DateTime('UTC'),
+                dt64 DateTime64(3, 'Europe/Moscow'),
+                dec Decimal(18, 4), uu UUID, ip4 IPv4, ip6 IPv6,
+                e Enum8('a' = 1, 'b' = 2), arr Array(UInt8),
+                m Map(String, UInt8), nn Nullable(UInt8), tup Tuple(UInt8, String)
+            ) ENGINE = Memory
+            """
+        )
+        row = (
+            7,
+            -5,
+            3.5,
+            "hi",
+            "abcd",
+            dt.date(2021, 5, 6),
+            dt.datetime(2021, 5, 6, 7, 8, 9),
+            dt.datetime(2021, 5, 6, 10, 8, 9, 123000),
+            Decimal("12.3456"),
+            UUID("1ea47c97-16a8-4338-877e-66f464374944"),
+            IPv4Address("1.2.3.4"),
+            IPv6Address("::1"),
+            "b",
+            [1, 2, 3],
+            {"k": 9},
+            None,
+            (4, "z"),
+        )
+        await binary.execute("INSERT INTO rb_insert VALUES", row)
+        # Read back with both engines: the binary insert must match exactly.
+        assert (await binary.fetchrow("SELECT * FROM rb_insert"))[:] == row
+        assert (await self.ch.fetchrow("SELECT * FROM rb_insert"))[:] == row
+        await binary.execute("DROP TABLE IF EXISTS rb_insert")
+
+    async def test_insert_with_column_list(self):
+        binary = self._binary_client()
+        await binary.execute("DROP TABLE IF EXISTS rb_insert_cols")
+        await binary.execute(
+            "CREATE TABLE rb_insert_cols (a UInt8, b String, c UInt8) ENGINE = Memory"
+        )
+        # Columns out of table order — types must be looked up in INSERT order.
+        await binary.execute("INSERT INTO rb_insert_cols (c, a) VALUES", (3, 1))
+        assert (await binary.fetchrow("SELECT a, b, c FROM rb_insert_cols"))[:] == (
+            1,
+            "",
+            3,
+        )
+        await binary.execute("DROP TABLE IF EXISTS rb_insert_cols")
 
 
 class TestErrorBody:


### PR DESCRIPTION
Extend the binary engine to INSERTs: ChClient(..., binary=True) now also encodes rows with RowBinary instead of VALUES text.