### PR TITLE
Binary protocols: RowBinary Cython acceleration + Native columnar engine (#134)

### DIFF
--- a/BENCHMARK_RESULTS.md
+++ b/BENCHMARK_RESULTS.md
@@ -1,0 +1,65 @@
+# aiochclient vs. other Python ClickHouse clients
+
+Throughput comparison against the most popular Python ClickHouse clients on a
+real-world-ish workload. Reproduce with `benchmarks_vs_libs.py`.
+
+## Workload
+
+- **Table** (`Memory` engine), mixed types similar to a typical events row:
+  `id UInt32, value Int64, score Float64, name String, created Date,
+  ts DateTime, tags Array(String), opt Nullable(Int32)`.
+- **SELECT**: `SELECT *` of **50,000** rows, fully materialized into Python
+  objects (list of row tuples). For aiochclient this forces decoding of every
+  field (`row[:]`); the other clients already return materialized rows.
+- **INSERT**: bulk-insert the same 50,000 rows (table truncated before each run).
+- Throughput = rows / best wall-clock over **8 sequential runs**, single
+  connection, **no async parallelism** (so this measures serialization /
+  deserialization cost, not IO concurrency).
+- Correctness was checked: every client returns the same 50,000 rows with
+  identical decoded values.
+
+## Environment
+
+- **Machine**: Apple M1 Pro, macOS (Darwin 23.6), CPython 3.11.
+- **ClickHouse**: 26.5 in Docker, local. HTTP on `:8123`, native TCP on `:9000`.
+- **Client versions**: aiochclient 2.7.0 + the RowBinary engine (with the Cython
+  extension built and `ciso8601` 2.3.3); clickhouse-connect 1.1.1;
+  clickhouse-driver 0.2.10; asynch 0.3.1; aiohttp 3.14.0.
+
+## Results (rows/sec, higher is better)
+
+| Client | Protocol | Async | SELECT (decode) | INSERT |
+|:-------|:---------|:-----:|----------------:|-------:|
+| **aiochclient — TSV** | HTTP | ✅ | ~265k | ~242k |
+| **aiochclient — RowBinary** | HTTP | ✅ | ~280k | ~310k |
+| clickhouse-connect | HTTP | ✅ | **~770k** | **~450k** |
+| asynch | native | ✅ | ~108k | ~158k |
+| clickhouse-driver | native | ❌ (sync) | ~455k | ~360k |
+
+Numbers are indicative (best-of-8; they vary ±10–20% run to run, INSERT more so)
+and depend on the data, the ClickHouse version and the machine.
+
+## Takeaways
+
+- **clickhouse-connect is the fastest** here, by a wide margin on SELECT. It is
+  the official client and decodes ClickHouse's **columnar** binary format in a C
+  extension, transposing to rows in bulk — much cheaper than any row-by-row
+  approach. If raw throughput is the only goal, it's the one to beat.
+- **clickhouse-driver** (native protocol, C extensions) is the next fastest, but
+  it is **synchronous** — not usable as-is in an asyncio app without a thread
+  pool.
+- **aiochclient's RowBinary engine** is the fastest of the lightweight,
+  row-oriented **async** options: it beats its own TSV path on both directions
+  and is faster than `asynch` (the async native driver) here, while keeping the
+  small, dependency-light, streaming, lazy-decoding HTTP design.
+- **asynch** is the slowest on SELECT in this test despite using the native
+  protocol — its async row materialization appears to be the bottleneck.
+
+### Where aiochclient could close the gap
+
+The remaining SELECT gap to clickhouse-connect is **columnar decoding**:
+aiochclient (and the native row drivers) decode row-by-row, while
+clickhouse-connect decodes whole columns at once in C. A columnar read path
+(e.g. ClickHouse's `Native` format) would be the architectural change needed to
+compete with it on raw read throughput — a possible future direction beyond the
+current RowBinary work.

--- a/BENCHMARK_RESULTS.md
+++ b/BENCHMARK_RESULTS.md
@@ -22,44 +22,50 @@ real-world-ish workload. Reproduce with `benchmarks_vs_libs.py`.
 
 - **Machine**: Apple M1 Pro, macOS (Darwin 23.6), CPython 3.11.
 - **ClickHouse**: 26.5 in Docker, local. HTTP on `:8123`, native TCP on `:9000`.
-- **Client versions**: aiochclient 2.7.0 + the RowBinary engine (with the Cython
-  extension built and `ciso8601` 2.3.3); clickhouse-connect 1.1.1;
-  clickhouse-driver 0.2.10; asynch 0.3.1; aiohttp 3.14.0.
+- **Client versions**: aiochclient 2.7.0 + the RowBinary and Native engines
+  (with the Cython extension built and `ciso8601` 2.3.3); clickhouse-connect
+  1.1.1; clickhouse-driver 0.2.10; asynch 0.3.1; aiohttp 3.14.0.
 
 ## Results (rows/sec, higher is better)
 
 | Client | Protocol | Async | SELECT (decode) | INSERT |
 |:-------|:---------|:-----:|----------------:|-------:|
-| **aiochclient — TSV** | HTTP | ✅ | ~265k | ~242k |
-| **aiochclient — RowBinary** | HTTP | ✅ | ~280k | ~310k |
-| clickhouse-connect | HTTP | ✅ | **~770k** | **~450k** |
-| asynch | native | ✅ | ~108k | ~158k |
-| clickhouse-driver | native | ❌ (sync) | ~455k | ~360k |
+| **aiochclient — Native** | HTTP | ✅ | **~730k** | ~330k |
+| **aiochclient — RowBinary** | HTTP | ✅ | ~370k | ~320k |
+| **aiochclient — TSV** | HTTP | ✅ | ~305k | ~245k |
+| clickhouse-connect | HTTP | ✅ | **~820k** | **~450k** |
+| asynch | native | ✅ | ~108k | ~165k |
+| clickhouse-driver | native | ❌ (sync) | ~440k | ~370k |
 
 Numbers are indicative (best-of-8; they vary ±10–20% run to run, INSERT more so)
 and depend on the data, the ClickHouse version and the machine.
 
 ## Takeaways
 
-- **clickhouse-connect is the fastest** here, by a wide margin on SELECT. It is
-  the official client and decodes ClickHouse's **columnar** binary format in a C
-  extension, transposing to rows in bulk — much cheaper than any row-by-row
-  approach. If raw throughput is the only goal, it's the one to beat.
-- **clickhouse-driver** (native protocol, C extensions) is the next fastest, but
-  it is **synchronous** — not usable as-is in an asyncio app without a thread
-  pool.
-- **aiochclient's RowBinary engine** is the fastest of the lightweight,
-  row-oriented **async** options: it beats its own TSV path on both directions
-  and is faster than `asynch` (the async native driver) here, while keeping the
-  small, dependency-light, streaming, lazy-decoding HTTP design.
-- **asynch** is the slowest on SELECT in this test despite using the native
-  protocol — its async row materialization appears to be the bottleneck.
+- **aiochclient's Native engine** is the fastest async option on SELECT here and
+  is within reach of clickhouse-connect — while keeping aiochclient's small,
+  dependency-light footprint (**no numpy**). It decodes ClickHouse's columnar
+  `Native` format whole-column-at-once: fixed-width numerics straight through the
+  stdlib `array` module, strings/dates in the compiled Cursor, then one transpose
+  to rows.
+- **clickhouse-connect is still the fastest** on SELECT (and INSERT). It is the
+  official client and decodes the columnar binary format in C on top of numpy;
+  the residual SELECT gap to aiochclient-Native is essentially the cost of
+  wrapping each row in aiochclient's richer `Record` object — the raw
+  column-decode-and-transpose throughput is comparable.
+- **clickhouse-driver** (native protocol, C extensions) is fast but
+  **synchronous** — not usable as-is in an asyncio app without a thread pool.
+  aiochclient-Native is faster than it on SELECT over plain HTTP.
+- **RowBinary** remains the best *row-oriented* engine (and the one used when
+  streaming row-by-row via `iterate`); **TSV** is the zero-Cython baseline.
+- **asynch** is the slowest on SELECT here despite the native protocol — its
+  async row materialization appears to be the bottleneck.
 
-### Where aiochclient could close the gap
+### Notes
 
-The remaining SELECT gap to clickhouse-connect is **columnar decoding**:
-aiochclient (and the native row drivers) decode row-by-row, while
-clickhouse-connect decodes whole columns at once in C. A columnar read path
-(e.g. ClickHouse's `Native` format) would be the architectural change needed to
-compete with it on raw read throughput — a possible future direction beyond the
-current RowBinary work.
+- The SELECT figures fully materialize every row (`row[:]`), so they measure
+  decode + `Record` construction, not lazy passthrough.
+- INSERT throughput is closer across clients: aiochclient-Native encodes numeric
+  columns in bulk via `array`, but variable-width / mixed columns still encode
+  per value, so its INSERT lands near RowBinary and clickhouse-driver rather than
+  ahead of them.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 2.8.0
+
+New — binary engines (both opt-in, TSV stays the default; pure-Python fallback
+kept when the Cython extension isn't built):
+
+- **Native columnar engine** — `ChClient(session, native=True)`. Decodes (and
+  encodes) ClickHouse's column-oriented `Native` format whole-column-at-once,
+  the fastest engine for SELECT, without numpy. Full type coverage including
+  `LowCardinality` and `Nested`; columnar INSERT.
+- **RowBinary engine** — `ChClient(session, binary=True)`, with a
+  Cython-accelerated reader. Faster than TSV in both directions and the right
+  choice for row-by-row `iterate` streaming (#134, #139, #140).
+- Compiled `Record` (a `cdef` class) — cheaper to build, speeds up every engine.
+
+Notes:
+- `decode=False` (raw bytes) is a TSV-only feature.
+- The Native format carries no per-column timezone, so a tz-aware
+  `DateTime`/`DateTime64` is returned as a naive UTC `datetime` (TSV and
+  RowBinary apply the timezone).
+
 ## 2.7.0
 
 **Requires Python >= 3.10** (tested on 3.10–3.13).

--- a/README.md
+++ b/README.md
@@ -162,6 +162,27 @@ rows = await client.fetch("SELECT * FROM t")
 Because RowBinary encoding is type-specific, a binary INSERT first looks up the
 target column types (one lightweight query) and encodes the rows to match them.
 
+#### TSV vs RowBinary speed
+
+With the Cython extension built, `RowBinary` is faster than `TSV` for both
+decoding and encoding (and avoids text-escaping entirely):
+
+| Engine      | SELECT (decode) | INSERT       |
+|:------------|----------------:|-------------:|
+| `TSV`       | ~185k rows/sec  | ~125k rows/sec |
+| `RowBinary` | ~210k rows/sec  | ~170k rows/sec |
+
+These figures are indicative — they depend on the data, the ClickHouse version
+and the machine, and the gap is larger for string-heavy rows. Reproduce them
+with `benchmarks.py` (the `bench_formats` benchmark).
+
+How it was measured: a 10,000-row table of mixed types (ints, `Float32`,
+`String`, `FixedString`, `Date`, `DateTime`, `Enum16`, `Nullable`,
+`Array(String)`, `UUID`); SELECT timings fully decode every row, INSERT timings
+clear the table before each run; best-of/average over many sequential runs on a
+single connection (no async parallelism). Environment: Apple M1 Pro, macOS,
+CPython 3.11 with the Cython extension, ClickHouse 26.5 over local HTTP.
+
 ## Documentation
 
 To check out the [api docs](https://aiochclient.readthedocs.io/en/latest/api.html),

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ fully typed interface.
 
 - [Installation](#installation)
 - [Quick Start](#quick-start)
+- [Binary engines: RowBinary and Native](#binary-engines-rowbinary-and-native)
 - [Documentation](#documentation)
 - [Type Conversion](#type-conversion)
 - [Connection Pool Settings](#connection-pool-settings)
@@ -147,41 +148,66 @@ assert list(row.keys()) == ["a", "b"]
 assert list(row.values()) == [1, (dt.date(2018, 9, 8), 3.14)]
 ```
 
-### RowBinary engine (experimental)
+### Binary engines: RowBinary and Native
 
 By default results are encoded/decoded through ClickHouse's text (TSV) format.
-You can instead use the binary `RowBinary` engine, which avoids text escaping
-entirely and is typically faster, for both SELECT and INSERT:
+Two faster binary engines are available, each opt-in via a single flag; both use
+the Cython extension when it's built and fall back to pure Python otherwise.
+
+**`native=True`** — ClickHouse's column-oriented `Native` format, the fastest
+engine for SELECT. Whole columns are decoded at once (fixed-width numerics
+straight through the stdlib `array` module, strings/dates in the compiled
+Cursor), which rivals the C-extension clients while keeping aiochclient
+dependency-light — **no numpy**. INSERTs are encoded column-by-column into a
+single Native block.
 
 ```python
-client = ChClient(session, binary=True)
+client = ChClient(session, native=True)
 await client.execute("INSERT INTO t VALUES", (1, "a"), (2, "b"))
 rows = await client.fetch("SELECT * FROM t")
 ```
 
-Because RowBinary encoding is type-specific, a binary INSERT first looks up the
+**`binary=True`** — the row-oriented `RowBinary` format. Faster than TSV in both
+directions, and the right choice when streaming row-by-row with `iterate`.
+
+```python
+client = ChClient(session, binary=True)
+```
+
+Because binary encoding is type-specific, a binary INSERT first looks up the
 target column types (one lightweight query) and encodes the rows to match them.
 
-#### TSV vs RowBinary speed
+A couple of `native=True` caveats: `decode=False` (raw bytes) is a TSV-only
+feature, and the Native format does not carry a column's timezone, so a tz-aware
+`DateTime`/`DateTime64` comes back as a naive UTC `datetime` (TSV and RowBinary
+apply the timezone).
 
-With the Cython extension built, `RowBinary` is faster than `TSV` for both
-decoding and encoding (and avoids text-escaping entirely):
+#### Speed
 
-| Engine      | SELECT (decode) | INSERT       |
-|:------------|----------------:|-------------:|
-| `TSV`       | ~185k rows/sec  | ~125k rows/sec |
-| `RowBinary` | ~210k rows/sec  | ~170k rows/sec |
+Engine comparison on mixed-type rows, fully decoded, with the Cython extension
+built:
 
-These figures are indicative — they depend on the data, the ClickHouse version
-and the machine, and the gap is larger for string-heavy rows. Reproduce them
-with `benchmarks.py` (the `bench_formats` benchmark).
+| Engine      | SELECT (decode) | INSERT         |
+|:------------|----------------:|---------------:|
+| `TSV`       | ~305k rows/sec  | ~245k rows/sec |
+| `RowBinary` | ~370k rows/sec  | ~320k rows/sec |
+| `Native`    | ~730k rows/sec  | ~330k rows/sec |
 
-How it was measured: a 10,000-row table of mixed types (ints, `Float32`,
-`String`, `FixedString`, `Date`, `DateTime`, `Enum16`, `Nullable`,
-`Array(String)`, `UUID`); SELECT timings fully decode every row, INSERT timings
-clear the table before each run; best-of/average over many sequential runs on a
-single connection (no async parallelism). Environment: Apple M1 Pro, macOS,
-CPython 3.11 with the Cython extension, ClickHouse 26.5 over local HTTP.
+Against the popular Python ClickHouse clients on the same workload, the Native
+engine is the fastest async SELECT option short of clickhouse-connect, and ahead
+of the synchronous clickhouse-driver:
+
+| Client                              | SELECT        | INSERT        |
+|:------------------------------------|--------------:|--------------:|
+| aiochclient — Native (HTTP, async)  | ~730k rows/sec | ~330k rows/sec |
+| clickhouse-connect (HTTP, async)    | ~820k rows/sec | ~450k rows/sec |
+| clickhouse-driver (native, sync)    | ~440k rows/sec | ~370k rows/sec |
+| asynch (native, async)              | ~108k rows/sec | ~165k rows/sec |
+
+Indicative best-of-8 figures (Apple M1 Pro, ClickHouse 26.5, single connection);
+they vary run to run and with the data. Full methodology lives in
+[BENCHMARK_RESULTS.md](BENCHMARK_RESULTS.md); reproduce with `benchmarks_vs_libs.py`
+(clients) and `benchmarks.py` (engines).
 
 ## Documentation
 

--- a/aiochclient/_types.pyx
+++ b/aiochclient/_types.pyx
@@ -261,6 +261,22 @@ cpdef tuple read_row(Cursor cursor, tuple readers):
     return tuple(out)
 
 
+cpdef list read_column(Cursor cursor, _RBType reader, Py_ssize_t n):
+    """Read ``n`` contiguous values of one scalar type (Native column fallback).
+
+    In the Native format a scalar column is just its RowBinary per-value
+    encodings laid out back to back, so the compiled per-type reader can be
+    looped at the C level to decode any fixed-layout scalar (Decimal, UUID,
+    DateTime64, Enum, IPv4/6, Int128/256, ...) without a bespoke bulk path.
+    """
+    cdef:
+        list out = []
+        Py_ssize_t i
+    for i in range(n):
+        out.append(reader.read(cursor))
+    return out
+
+
 cdef datetime _datetime_parse(str string):
     return datetime.strptime(string, '%Y-%m-%d %H:%M:%S')
 

--- a/aiochclient/_types.pyx
+++ b/aiochclient/_types.pyx
@@ -19,7 +19,47 @@ from libc.stdint cimport (
     uint64_t,
 )
 
-from aiochclient.exceptions import ChClientError
+from aiochclient.exceptions import ChClientError, NeedMoreData
+
+
+cdef class Cursor:
+    """Fast forward cursor over a bytes buffer (RowBinary engine)."""
+
+    cdef:
+        bytes buf
+        public Py_ssize_t pos
+        Py_ssize_t size
+
+    def __init__(self, bytes buf=b"", Py_ssize_t pos=0):
+        self.buf = buf
+        self.pos = pos
+        self.size = len(buf)
+
+    cpdef bytes read(self, Py_ssize_t n):
+        cdef Py_ssize_t end = self.pos + n
+        if end > self.size:
+            raise NeedMoreData()
+        cdef bytes chunk = self.buf[self.pos:end]
+        self.pos = end
+        return chunk
+
+    cpdef read_varint(self):
+        cdef:
+            const unsigned char* data = self.buf
+            Py_ssize_t pos = self.pos
+            unsigned long long result = 0
+            int shift = 0
+            unsigned char byte
+        while True:
+            if pos >= self.size:
+                raise NeedMoreData()
+            byte = data[pos]
+            pos += 1
+            result |= (<unsigned long long>(byte & 0x7F)) << shift
+            if not (byte & 0x80):
+                self.pos = pos
+                return result
+            shift += 7
 
 
 cdef datetime _datetime_parse(str string):

--- a/aiochclient/_types.pyx
+++ b/aiochclient/_types.pyx
@@ -3,6 +3,7 @@ import datetime as _dt
 import json
 import re
 import struct
+from collections.abc import ItemsView, KeysView, Mapping, ValuesView
 from decimal import Decimal
 from ipaddress import IPv4Address, IPv6Address
 from uuid import UUID
@@ -1565,3 +1566,117 @@ def json2ch(*records, dumps):
 
 def empty_convertor(bytes value):
     return value
+
+
+cdef class Record:
+    """Compiled mirror of :class:`aiochclient.records.Record`.
+
+    A ``cdef class`` instantiates far more cheaply than a pure-Python
+    ``Mapping`` subclass, which matters when a single ``fetch`` wraps tens of
+    thousands of rows. It cannot inherit from ``Mapping`` (cython forbids the
+    ABCMeta metaclass), so the mapping interface is implemented explicitly and
+    the class is registered as a virtual ``Mapping`` for ``isinstance`` checks.
+    """
+
+    cdef public object _row
+    cdef public dict _names
+    cdef public list _converters
+    cdef bint _decoded
+
+    def __init__(self, row, dict names, list converters):
+        self._row = row
+        if not row:
+            # in case of empty row (e.g. a WITH TOTALS placeholder)
+            self._decoded = True
+            self._converters = []
+            self._names = {}
+        else:
+            self._decoded = False
+            self._converters = converters
+            self._names = names
+
+    @classmethod
+    def from_decoded(cls, tuple values, dict names):
+        """Build a record from already-decoded values (binary/native path)."""
+        return record_new(values, names)
+
+    cdef _decode(self):
+        if self._decoded:
+            return
+        self._row = tuple(
+            converter(val)
+            for converter, val in zip(self._converters, self._row.split(b"\t"))
+        )
+        self._decoded = True
+
+    cdef _getitem(self, key):
+        if type(key) is str:
+            try:
+                return self._row[self._names[key]]
+            except KeyError:
+                if not self._row:
+                    raise KeyError(
+                        "Empty row. May be it is result of 'WITH TOTALS' query."
+                    )
+                raise KeyError(f"No fields with name '{key}'")
+        try:
+            return self._row[key]
+        except IndexError:
+            if not self._row:
+                raise IndexError(
+                    "Empty row. May be it is result of 'WITH TOTALS' query."
+                )
+            raise IndexError(f"No fields with index '{key}'")
+
+    def __getitem__(self, key):
+        if not self._decoded:
+            self._decode()
+        return self._getitem(key)
+
+    def __iter__(self):
+        return iter(self._names)
+
+    def __len__(self):
+        return len(self._names)
+
+    # -- collections.abc.Mapping mixin interface (matched semantics) --
+    def __contains__(self, key):
+        try:
+            self[key]
+        except KeyError:
+            return False
+        return True
+
+    def keys(self):
+        return KeysView(self)
+
+    def items(self):
+        return ItemsView(self)
+
+    def values(self):
+        return ValuesView(self)
+
+    def get(self, key, default=None):
+        try:
+            return self[key]
+        except KeyError:
+            return default
+
+    def __eq__(self, other):
+        return isinstance(other, Mapping) and dict(self) == dict(other)
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+
+Mapping.register(Record)
+
+
+cpdef Record record_new(tuple values, dict names):
+    """Fast path: wrap already-decoded ``values`` without going through __init__."""
+    cdef Record record = Record.__new__(Record)
+    record._row = values
+    record._names = names
+    record._converters = None
+    record._decoded = True
+    return record

--- a/aiochclient/_types.pyx
+++ b/aiochclient/_types.pyx
@@ -9,7 +9,14 @@ from uuid import UUID
 from zoneinfo import ZoneInfo
 
 from cpython cimport PyList_Append, PyUnicode_AsEncodedString, PyUnicode_Join
-from cpython.datetime cimport date, datetime
+from cpython.datetime cimport (
+    date,
+    date_new,
+    datetime,
+    datetime_new,
+    import_datetime,
+)
+from cpython.unicode cimport PyUnicode_DecodeUTF8
 from cpython.mem cimport PyMem_Free, PyMem_Malloc
 from libc.stdint cimport (
     int8_t,
@@ -24,6 +31,26 @@ from libc.stdint cimport (
 from libc.string cimport memcpy
 
 from aiochclient.exceptions import ChClientError, NeedMoreData
+
+import_datetime()
+
+
+cdef inline void _civil_from_days(long long z, int* y, int* m, int* d):
+    # Howard Hinnant's algorithm: days since 1970-01-01 -> (year, month, day).
+    z += 719468
+    cdef long long era = (z if z >= 0 else z - 146096) // 146097
+    cdef long long doe = z - era * 146097
+    cdef long long yoe = (doe - doe // 1460 + doe // 36524 - doe // 146096) // 365
+    cdef long long year = yoe + era * 400
+    cdef long long doy = doe - (365 * yoe + yoe // 4 - yoe // 100)
+    cdef long long mp = (5 * doy + 2) // 153
+    cdef long long day = doy - (153 * mp + 2) // 5 + 1
+    cdef long long month = mp + 3 if mp < 10 else mp - 9
+    if month <= 2:
+        year += 1
+    y[0] = <int>year
+    m[0] = <int>month
+    d[0] = <int>day
 
 
 cdef class Cursor:
@@ -101,6 +128,82 @@ cdef class Cursor:
         memcpy(&value, (<const char*>self.buf) + self.pos, 4)
         self.pos += 4
         return value
+
+    # -- Native engine: whole-column bulk reads (raise NeedMoreData on short) --
+
+    cpdef list read_string_column(self, Py_ssize_t n):
+        cdef:
+            const unsigned char* data = self.buf
+            Py_ssize_t pos = self.pos
+            Py_ssize_t size = self.size
+            list out = []
+            Py_ssize_t i, length, shift, end
+            unsigned char b
+        for i in range(n):
+            length = 0
+            shift = 0
+            while True:
+                if pos >= size:
+                    raise NeedMoreData()
+                b = data[pos]
+                pos += 1
+                length |= (<Py_ssize_t>(b & 0x7F)) << shift
+                if not (b & 0x80):
+                    break
+                shift += 7
+            end = pos + length
+            if end > size:
+                raise NeedMoreData()
+            out.append(PyUnicode_DecodeUTF8(<char*>data + pos, length, NULL))
+            pos = end
+        self.pos = pos
+        return out
+
+    cpdef list read_date_column(self, Py_ssize_t n):
+        cdef:
+            const unsigned char* data = self.buf
+            Py_ssize_t pos = self.pos
+            list out = []
+            Py_ssize_t i
+            unsigned int days
+            int y, m, d
+        if pos + n * 2 > self.size:
+            raise NeedMoreData()
+        for i in range(n):
+            days = data[pos] | (data[pos + 1] << 8)
+            pos += 2
+            _civil_from_days(days, &y, &m, &d)
+            out.append(date_new(y, m, d))
+        self.pos = pos
+        return out
+
+    cpdef list read_datetime_column(self, Py_ssize_t n):
+        cdef:
+            const unsigned char* data = self.buf
+            Py_ssize_t pos = self.pos
+            list out = []
+            Py_ssize_t i
+            unsigned long long secs
+            int rem, y, m, d, hh, mm, ss
+        if pos + n * 4 > self.size:
+            raise NeedMoreData()
+        for i in range(n):
+            secs = (
+                data[pos]
+                | (data[pos + 1] << 8)
+                | (data[pos + 2] << 16)
+                | (<unsigned long long>data[pos + 3] << 24)
+            )
+            pos += 4
+            _civil_from_days(<long long>(secs // 86400), &y, &m, &d)
+            rem = <int>(secs % 86400)
+            hh = rem // 3600
+            rem = rem % 3600
+            mm = rem // 60
+            ss = rem % 60
+            out.append(datetime_new(y, m, d, hh, mm, ss, 0, None))
+        self.pos = pos
+        return out
 
 
 # ---- RowBinary engine: base type with virtual read/write -------------------

--- a/aiochclient/_types.pyx
+++ b/aiochclient/_types.pyx
@@ -1,9 +1,12 @@
 #cython: language_level=3
+import datetime as _dt
 import json
 import re
+import struct
 from decimal import Decimal
 from ipaddress import IPv4Address, IPv6Address
 from uuid import UUID
+from zoneinfo import ZoneInfo
 
 from cpython cimport PyList_Append, PyUnicode_AsEncodedString, PyUnicode_Join
 from cpython.datetime cimport date, datetime
@@ -18,6 +21,7 @@ from libc.stdint cimport (
     uint32_t,
     uint64_t,
 )
+from libc.string cimport memcpy
 
 from aiochclient.exceptions import ChClientError, NeedMoreData
 
@@ -60,6 +64,97 @@ cdef class Cursor:
                 self.pos = pos
                 return result
             shift += 7
+
+    cpdef object read_int(self, int size, bint signed):
+        # Wider than 64 bits (Int128/256, Decimal128/256) -> python big-int.
+        if size > 8:
+            return int.from_bytes(self.read(size), "little", signed=signed)
+        cdef:
+            const unsigned char* data
+            Py_ssize_t pos = self.pos
+            uint64_t u = 0
+            int i
+        if pos + size > self.size:
+            raise NeedMoreData()
+        data = self.buf
+        for i in range(size):
+            u |= (<uint64_t>data[pos + i]) << (8 * i)
+        self.pos = pos + size
+        if signed:
+            if size < 8 and (u >> (size * 8 - 1)) & 1:
+                u |= (<uint64_t>0xFFFFFFFFFFFFFFFF) << (size * 8)
+            return <int64_t>u
+        return u
+
+    cpdef double read_double(self):
+        cdef double value
+        if self.pos + 8 > self.size:
+            raise NeedMoreData()
+        memcpy(&value, (<const char*>self.buf) + self.pos, 8)
+        self.pos += 8
+        return value
+
+    cpdef double read_float(self):
+        cdef float value
+        if self.pos + 4 > self.size:
+            raise NeedMoreData()
+        memcpy(&value, (<const char*>self.buf) + self.pos, 4)
+        self.pos += 4
+        return value
+
+
+# ---- RowBinary engine: base type with virtual read/write -------------------
+
+RB_EPOCH_DATE = _dt.date(1970, 1, 1)
+RB_EPOCH_DATETIME = _dt.datetime(1970, 1, 1)
+RB_EPOCH_UTC = _dt.datetime(1970, 1, 1, tzinfo=_dt.timezone.utc)
+_TZ_UNSET = object()
+
+
+cdef bytes rb_write_varint(unsigned long long value):
+    cdef bytearray out = bytearray()
+    cdef unsigned char byte
+    while True:
+        byte = value & 0x7F
+        value >>= 7
+        if value:
+            out.append(byte | 0x80)
+        else:
+            out.append(byte)
+            return bytes(out)
+
+
+cdef str rb_parse_tz(str name):
+    cdef Py_ssize_t first, last
+    if "'" in name:
+        first = name.index("'")
+        last = name.rindex("'")
+        return name[first + 1:last].replace("\\", "")
+    return None
+
+
+cdef class _RBType:
+    """Base for the RowBinary read/write virtual dispatch."""
+
+    cdef object read(self, Cursor cursor):
+        raise ChClientError(
+            f"RowBinary decoding is not implemented for type '{type(self).__name__}'"
+        )
+
+    cpdef bytes write(self, value):
+        raise ChClientError(
+            f"RowBinary encoding is not implemented for type '{type(self).__name__}'"
+        )
+
+
+cpdef tuple read_row(Cursor cursor, tuple readers):
+    """Read one RowBinary row given the column type objects (fast dispatch)."""
+    cdef:
+        _RBType reader
+        list out = []
+    for reader in readers:
+        out.append(reader.read(cursor))
+    return tuple(out)
 
 
 cdef datetime _datetime_parse(str string):
@@ -236,7 +331,7 @@ cdef tuple _split_map_kv(str pair):
     return pair, ""
 
 
-cdef class StrType:
+cdef class StrType(_RBType):
 
     cdef:
         str name
@@ -262,8 +357,24 @@ cdef class StrType:
         # example, turn a literal ``\t`` into a tab or drop a trailing backslash.
         return self._convert(value.decode())
 
+    cdef object read(self, Cursor cursor):
+        cdef Py_ssize_t length
+        if self.name[0] == "F":  # FixedString(N)
+            length = int(self.name[12:-1])
+        else:
+            length = cursor.read_varint()
+        return cursor.read(length).decode()
 
-cdef class BoolType:
+    cpdef bytes write(self, value):
+        cdef bytes data = value.encode()
+        cdef Py_ssize_t length
+        if self.name[0] == "F":
+            length = int(self.name[12:-1])
+            return data[:length].ljust(length, b"\x00")
+        return rb_write_varint(len(data)) + data
+
+
+cdef class BoolType(_RBType):
 
     cdef:
         str name
@@ -284,8 +395,14 @@ cdef class BoolType:
     cpdef bint convert(self, bytes value):
         return self.p_type(value.decode())
 
+    cdef object read(self, Cursor cursor):
+        return cursor.read_int(1, False) != 0
 
-cdef class Int8Type:
+    cpdef bytes write(self, value):
+        return b"\x01" if value else b"\x00"
+
+
+cdef class Int8Type(_RBType):
 
     cdef:
         str name
@@ -301,8 +418,14 @@ cdef class Int8Type:
     cpdef int8_t convert(self, bytes value):
         return int(value)
 
+    cdef object read(self, Cursor cursor):
+        return cursor.read_int(1, True)
 
-cdef class Int16Type:
+    cpdef bytes write(self, value):
+        return int(value).to_bytes(1, "little", signed=True)
+
+
+cdef class Int16Type(_RBType):
 
     cdef:
         str name
@@ -318,8 +441,14 @@ cdef class Int16Type:
     cpdef int16_t convert(self, bytes value):
         return int(value)
 
+    cdef object read(self, Cursor cursor):
+        return cursor.read_int(2, True)
 
-cdef class Int32Type:
+    cpdef bytes write(self, value):
+        return int(value).to_bytes(2, "little", signed=True)
+
+
+cdef class Int32Type(_RBType):
 
     cdef:
         str name
@@ -335,8 +464,14 @@ cdef class Int32Type:
     cpdef int32_t convert(self, bytes value):
         return int(value)
 
+    cdef object read(self, Cursor cursor):
+        return cursor.read_int(4, True)
 
-cdef class Int64Type:
+    cpdef bytes write(self, value):
+        return int(value).to_bytes(4, "little", signed=True)
+
+
+cdef class Int64Type(_RBType):
 
     cdef:
         str name
@@ -352,8 +487,14 @@ cdef class Int64Type:
     cpdef int64_t convert(self, bytes value):
         return int(value)
 
+    cdef object read(self, Cursor cursor):
+        return cursor.read_int(8, True)
 
-cdef class Int128Type:
+    cpdef bytes write(self, value):
+        return int(value).to_bytes(8, "little", signed=True)
+
+
+cdef class Int128Type(_RBType):
 
     cdef:
         str name
@@ -369,8 +510,14 @@ cdef class Int128Type:
     cpdef int128 convert(self, bytes value):
         return int(value)
 
+    cdef object read(self, Cursor cursor):
+        return cursor.read_int(16, True)
 
-cdef class Int256Type:
+    cpdef bytes write(self, value):
+        return int(value).to_bytes(16, "little", signed=True)
+
+
+cdef class Int256Type(_RBType):
 
     cdef:
         str name
@@ -386,8 +533,14 @@ cdef class Int256Type:
     cpdef convert(self, bytes value):
         return int(value)
 
+    cdef object read(self, Cursor cursor):
+        return cursor.read_int(32, True)
 
-cdef class UInt8Type:
+    cpdef bytes write(self, value):
+        return int(value).to_bytes(32, "little", signed=True)
+
+
+cdef class UInt8Type(_RBType):
 
     cdef:
         str name
@@ -403,8 +556,14 @@ cdef class UInt8Type:
     cpdef uint8_t convert(self, bytes value):
         return int(value)
 
+    cdef object read(self, Cursor cursor):
+        return cursor.read_int(1, False)
 
-cdef class UInt16Type:
+    cpdef bytes write(self, value):
+        return int(value).to_bytes(1, "little")
+
+
+cdef class UInt16Type(_RBType):
 
     cdef:
         str name
@@ -420,8 +579,14 @@ cdef class UInt16Type:
     cpdef uint16_t convert(self, bytes value):
         return int(value)
 
+    cdef object read(self, Cursor cursor):
+        return cursor.read_int(2, False)
 
-cdef class UInt32Type:
+    cpdef bytes write(self, value):
+        return int(value).to_bytes(2, "little")
+
+
+cdef class UInt32Type(_RBType):
 
     cdef:
         str name
@@ -437,8 +602,14 @@ cdef class UInt32Type:
     cpdef uint32_t convert(self, bytes value):
         return int(value)
 
+    cdef object read(self, Cursor cursor):
+        return cursor.read_int(4, False)
 
-cdef class UInt64Type:
+    cpdef bytes write(self, value):
+        return int(value).to_bytes(4, "little")
+
+
+cdef class UInt64Type(_RBType):
 
     cdef:
         str name
@@ -454,8 +625,14 @@ cdef class UInt64Type:
     cpdef uint64_t convert(self, bytes value):
         return int(value)
 
+    cdef object read(self, Cursor cursor):
+        return cursor.read_int(8, False)
 
-cdef class UInt128Type:
+    cpdef bytes write(self, value):
+        return int(value).to_bytes(8, "little")
+
+
+cdef class UInt128Type(_RBType):
 
     cdef:
         str name
@@ -471,8 +648,14 @@ cdef class UInt128Type:
     cpdef uint128 convert(self, bytes value):
         return int(value)
 
+    cdef object read(self, Cursor cursor):
+        return cursor.read_int(16, False)
 
-cdef class UInt256Type:
+    cpdef bytes write(self, value):
+        return int(value).to_bytes(16, "little")
+
+
+cdef class UInt256Type(_RBType):
 
     cdef:
         str name
@@ -488,8 +671,14 @@ cdef class UInt256Type:
     cpdef convert(self, bytes value):
         return int(value)
 
+    cdef object read(self, Cursor cursor):
+        return cursor.read_int(32, False)
 
-cdef class FloatType:
+    cpdef bytes write(self, value):
+        return int(value).to_bytes(32, "little")
+
+
+cdef class FloatType(_RBType):
 
     cdef:
         str name
@@ -505,8 +694,18 @@ cdef class FloatType:
     cpdef double convert(self, bytes value):
         return float(value)
 
+    cdef object read(self, Cursor cursor):
+        if self.name == "Float64":
+            return cursor.read_double()
+        return cursor.read_float()
 
-cdef class DateType:
+    cpdef bytes write(self, value):
+        if self.name == "Float64":
+            return struct.pack("<d", value)
+        return struct.pack("<f", value)
+
+
+cdef class DateType(_RBType):
 
     cdef:
         str name
@@ -532,16 +731,31 @@ cdef class DateType:
     cpdef object convert(self, bytes value):
         return self._convert(value.decode())
 
+    cdef object read(self, Cursor cursor):
+        return RB_EPOCH_DATE + _dt.timedelta(days=cursor.read_int(2, False))
 
-cdef class DateTimeType:
+    cpdef bytes write(self, value):
+        return (value - RB_EPOCH_DATE).days.to_bytes(2, "little")
+
+
+cdef class DateTimeType(_RBType):
 
     cdef:
         str name
         bint container
+        str _tz_name
+        object _tz
 
     def __cinit__(self, str name, bint container):
         self.name = name
         self.container = container
+        self._tz_name = rb_parse_tz(name)
+        self._tz = _TZ_UNSET
+
+    cdef object _zone(self):
+        if self._tz is _TZ_UNSET:
+            self._tz = ZoneInfo(self._tz_name) if self._tz_name else None
+        return self._tz
 
     cdef object _convert(self, str string):
         string = string.strip("'")
@@ -559,16 +773,42 @@ cdef class DateTimeType:
     cpdef object convert(self, bytes value):
         return self._convert(value.decode())
 
+    cdef object read(self, Cursor cursor):
+        seconds = cursor.read_int(4, False)
+        zone = self._zone()
+        if zone is None:
+            return RB_EPOCH_DATETIME + _dt.timedelta(seconds=seconds)
+        return _dt.datetime.fromtimestamp(seconds, zone).replace(tzinfo=None)
 
-cdef class DateTime64Type:
+    cpdef bytes write(self, value):
+        zone = self._zone()
+        if zone is None:
+            seconds = (value - RB_EPOCH_DATETIME) // _dt.timedelta(seconds=1)
+        else:
+            seconds = int(value.replace(tzinfo=zone).timestamp())
+        return int(seconds).to_bytes(4, "little")
+
+
+cdef class DateTime64Type(_RBType):
 
     cdef:
         str name
         bint container
+        int _precision
+        str _tz_name
+        object _tz
 
     def __cinit__(self, str name, bint container):
         self.name = name
         self.container = container
+        self._precision = int(name[name.index("(") + 1:].split(",")[0].split(")")[0])
+        self._tz_name = rb_parse_tz(name)
+        self._tz = _TZ_UNSET
+
+    cdef object _zone(self):
+        if self._tz is _TZ_UNSET:
+            self._tz = ZoneInfo(self._tz_name) if self._tz_name else None
+        return self._tz
 
     cdef object _convert(self, str string):
         string = string.strip("'")
@@ -586,8 +826,35 @@ cdef class DateTime64Type:
     cpdef object convert(self, bytes value):
         return self._convert(value.decode())
 
+    cdef object read(self, Cursor cursor):
+        ticks = cursor.read_int(8, True)
+        if self._precision <= 6:
+            micros = ticks * 10 ** (6 - self._precision)
+        else:
+            micros = ticks // 10 ** (self._precision - 6)
+        zone = self._zone()
+        if zone is None:
+            return RB_EPOCH_DATETIME + _dt.timedelta(microseconds=micros)
+        return (RB_EPOCH_UTC + _dt.timedelta(microseconds=micros)).astimezone(
+            zone
+        ).replace(tzinfo=None)
 
-cdef class TupleType:
+    cpdef bytes write(self, value):
+        zone = self._zone()
+        if zone is None:
+            micros = (value - RB_EPOCH_DATETIME) // _dt.timedelta(microseconds=1)
+        else:
+            micros = (value.replace(tzinfo=zone) - RB_EPOCH_UTC) // _dt.timedelta(
+                microseconds=1
+            )
+        if self._precision <= 6:
+            ticks = micros // 10 ** (6 - self._precision)
+        else:
+            ticks = micros * 10 ** (self._precision - 6)
+        return int(ticks).to_bytes(8, "little", signed=True)
+
+
+cdef class TupleType(_RBType):
 
     cdef:
         str name
@@ -598,11 +865,13 @@ cdef class TupleType:
         self.name = name
         self.container = container
         cdef str tps = RE_TUPLE.findall(name)[0]
-        self.types = tuple(what_py_type(tp.rpartition(" ")[2], container=True).p_type for tp in tps.split(","))
+        self.types = tuple(
+            what_py_type(tp.rpartition(" ")[2], container=True) for tp in tps.split(",")
+        )
 
     cdef tuple _convert(self, str string):
         return tuple(
-            tp(val)
+            tp.p_type(val)
             for tp, val in zip(self.types, seq_parser(string[1:-1]))
         )
 
@@ -612,8 +881,26 @@ cdef class TupleType:
     cpdef tuple convert(self, bytes value):
         return self._convert(value.decode())
 
+    cdef object read(self, Cursor cursor):
+        cdef:
+            _RBType tp
+            list out = []
+        for tp in self.types:
+            out.append(tp.read(cursor))
+        return tuple(out)
 
-cdef class MapType:
+    cpdef bytes write(self, value):
+        cdef:
+            _RBType tp
+            list parts = []
+            Py_ssize_t i = 0
+        for tp in self.types:
+            parts.append(tp.write(value[i]))
+            i += 1
+        return b"".join(parts)
+
+
+cdef class MapType(_RBType):
 
     cdef:
         str name
@@ -628,6 +915,28 @@ cdef class MapType:
         comma_index = tps.index(",")
         self.key_type = what_py_type(tps[:comma_index], container=True)
         self.value_type = what_py_type(tps[comma_index + 1:], container=True)
+
+    cdef object read(self, Cursor cursor):
+        cdef:
+            Py_ssize_t n = cursor.read_varint()
+            Py_ssize_t i
+            dict out = {}
+            _RBType k = <_RBType>self.key_type
+            _RBType v = <_RBType>self.value_type
+        for i in range(n):
+            key = k.read(cursor)
+            out[key] = v.read(cursor)
+        return out
+
+    cpdef bytes write(self, value):
+        cdef:
+            _RBType k = <_RBType>self.key_type
+            _RBType v = <_RBType>self.value_type
+            list parts = [rb_write_varint(len(value))]
+        for key in value:
+            parts.append(k.write(key))
+            parts.append(v.write(value[key]))
+        return b"".join(parts)
 
     cdef dict _convert(self, str string):
         cdef:
@@ -645,7 +954,7 @@ cdef class MapType:
         return self._convert(value.decode())
 
 
-cdef class ArrayType:
+cdef class ArrayType(_RBType):
 
     cdef:
         str name
@@ -659,6 +968,24 @@ cdef class ArrayType:
             RE_ARRAY.findall(name)[0], container=True
         )
 
+    cdef object read(self, Cursor cursor):
+        cdef:
+            Py_ssize_t n = cursor.read_varint()
+            Py_ssize_t i
+            list out = []
+            _RBType element = <_RBType>self.type
+        for i in range(n):
+            out.append(element.read(cursor))
+        return out
+
+    cpdef bytes write(self, value):
+        cdef:
+            _RBType element = <_RBType>self.type
+            list parts = [rb_write_varint(len(value))]
+        for elem in value:
+            parts.append(element.write(elem))
+        return b"".join(parts)
+
     cdef list _convert(self, str string):
         return [self.type.p_type(val) for val in seq_parser(string[1:-1])]
 
@@ -669,8 +996,8 @@ cdef class ArrayType:
         return self.p_type(value.decode())
 
 
-cdef class NestedType:
-    
+cdef class NestedType(_RBType):
+
     cdef:
         str name
         bint container
@@ -683,6 +1010,31 @@ cdef class NestedType:
             what_py_type(i.split()[1], container=True)
             for i in RE_NESTED.findall(name)[0].split(',')
         )
+
+    cdef object read(self, Cursor cursor):
+        cdef:
+            Py_ssize_t n = cursor.read_varint()
+            Py_ssize_t i
+            list out = []
+            _RBType tp
+        for i in range(n):
+            row = []
+            for tp in self.types:
+                row.append(tp.read(cursor))
+            out.append(tuple(row))
+        return out
+
+    cpdef bytes write(self, value):
+        cdef:
+            _RBType tp
+            list parts = [rb_write_varint(len(value))]
+            Py_ssize_t j
+        for row in value:
+            j = 0
+            for tp in self.types:
+                parts.append(tp.write(row[j]))
+                j += 1
+        return b"".join(parts)
 
     cdef list _convert(self, str string):
         return self.p_type(string)
@@ -699,7 +1051,7 @@ cdef class NestedType:
     cpdef list convert(self, bytes value):
         return self._convert(value.decode())
 
-cdef class NullableType:
+cdef class NullableType(_RBType):
 
     cdef:
         str name
@@ -710,6 +1062,16 @@ cdef class NullableType:
         self.name = name
         self.container = container
         self.type = what_py_type(RE_NULLABLE.findall(name)[0], container)
+
+    cdef object read(self, Cursor cursor):
+        if cursor.read(1) != b"\x00":
+            return None
+        return (<_RBType>self.type).read(cursor)
+
+    cpdef bytes write(self, value):
+        if value is None:
+            return b"\x01"
+        return b"\x00" + (<_RBType>self.type).write(value)
 
     cdef _convert(self, str string):
         if string == r"\N" or string == "NULL":
@@ -723,7 +1085,7 @@ cdef class NullableType:
         return self._convert(decode(value))
 
 
-cdef class NothingType:
+cdef class NothingType(_RBType):
 
     cdef:
         str name
@@ -739,8 +1101,14 @@ cdef class NothingType:
     cpdef void convert(self, bytes value):
         pass
 
+    cdef object read(self, Cursor cursor):
+        return None
 
-cdef class UUIDType:
+    cpdef bytes write(self, value):
+        return b""
+
+
+cdef class UUIDType(_RBType):
 
     cdef:
         str name
@@ -759,8 +1127,23 @@ cdef class UUIDType:
     cpdef object convert(self, bytes value):
         return self._convert(value.decode())
 
+    cdef object read(self, Cursor cursor):
+        cdef bytes data = cursor.read(16)
+        return UUID(
+            int=(int.from_bytes(data[:8], "little") << 64)
+            | int.from_bytes(data[8:], "little")
+        )
 
-cdef class IPv4Type:
+    cpdef bytes write(self, value):
+        if not isinstance(value, UUID):
+            value = UUID(str(value))
+        cdef object number = value.int
+        return (number >> 64).to_bytes(8, "little") + (
+            number & 0xFFFFFFFFFFFFFFFF
+        ).to_bytes(8, "little")
+
+
+cdef class IPv4Type(_RBType):
 
     cdef:
         str name
@@ -779,8 +1162,14 @@ cdef class IPv4Type:
     cpdef object convert(self, bytes value):
         return self._convert(value.decode())
 
+    cdef object read(self, Cursor cursor):
+        return IPv4Address(cursor.read_int(4, False))
 
-cdef class IPv6Type:
+    cpdef bytes write(self, value):
+        return int(IPv4Address(value)).to_bytes(4, "little")
+
+
+cdef class IPv6Type(_RBType):
 
     cdef:
         str name
@@ -799,8 +1188,14 @@ cdef class IPv6Type:
     cpdef object convert(self, bytes value):
         return self._convert(value.decode())
 
+    cdef object read(self, Cursor cursor):
+        return IPv6Address(cursor.read(16))
 
-cdef class LowCardinalityType:
+    cpdef bytes write(self, value):
+        return IPv6Address(value).packed
+
+
+cdef class LowCardinalityType(_RBType):
 
     cdef:
         str name
@@ -821,22 +1216,78 @@ cdef class LowCardinalityType:
     cpdef object convert(self, bytes value):
         return self._convert(decode(value))
 
+    cdef object read(self, Cursor cursor):
+        return (<_RBType>self.type).read(cursor)
 
-cdef class DecimalType:
+    cpdef bytes write(self, value):
+        return (<_RBType>self.type).write(value)
+
+
+cdef class DecimalType(_RBType):
 
     cdef:
         str name
         bint container
+        int _size
+        int _scale
 
     def __cinit__(self, str name, bint container):
         self.name = name
         self.container = container
+        cdef list nums = [int(n) for n in re.findall(r"\d+", name)]
+        cdef int precision
+        if name.startswith("Decimal("):
+            precision = nums[0]
+            self._scale = nums[1]
+        else:
+            precision = {
+                "Decimal32": 9,
+                "Decimal64": 18,
+                "Decimal128": 38,
+                "Decimal256": 76,
+            }[name.split("(")[0]]
+            self._scale = nums[-1]
+        self._size = (
+            4 if precision <= 9 else 8 if precision <= 18 else 16 if precision <= 38 else 32
+        )
 
     cpdef object p_type(self, str string):
         return Decimal(string)
 
     cpdef object convert(self, bytes value):
         return Decimal(value.decode())
+
+    cdef object read(self, Cursor cursor):
+        return Decimal(cursor.read_int(self._size, True)).scaleb(-self._scale)
+
+    cpdef bytes write(self, value):
+        return int(Decimal(value).scaleb(self._scale)).to_bytes(
+            self._size, "little", signed=True
+        )
+
+
+cdef class EnumType(StrType):
+    """Enum8/Enum16: TSV gives the label (handled by StrType); RowBinary gives
+    the signed integer index, mapped back to its label here."""
+
+    cdef:
+        int _size
+        dict _mapping
+        dict _reverse
+
+    def __cinit__(self, str name, bint container):
+        self._size = 1 if name.startswith("Enum8") else 2
+        self._mapping = {
+            int(num): label
+            for label, num in re.findall(r"'((?:[^'\\]|\\.)*)'\s*=\s*(-?\d+)", name)
+        }
+        self._reverse = {label: index for index, label in self._mapping.items()}
+
+    cdef object read(self, Cursor cursor):
+        return self._mapping[cursor.read_int(self._size, True)]
+
+    cpdef bytes write(self, value):
+        return self._reverse[value].to_bytes(self._size, "little", signed=True)
 
 
 cdef dict CH_TYPES_MAPPING = {
@@ -845,8 +1296,8 @@ cdef dict CH_TYPES_MAPPING = {
     "UInt16": UInt16Type,
     "UInt32": UInt32Type,
     "UInt64": UInt64Type,
-    "UInt128": Int128Type,
-    "UInt256": Int256Type,
+    "UInt128": UInt128Type,
+    "UInt256": UInt256Type,
     "Int8": Int8Type,
     "Int16": Int16Type,
     "Int32": Int32Type,
@@ -857,8 +1308,8 @@ cdef dict CH_TYPES_MAPPING = {
     "Float64": FloatType,
     "String": StrType,
     "FixedString": StrType,
-    "Enum8": StrType,
-    "Enum16": StrType,
+    "Enum8": EnumType,
+    "Enum16": EnumType,
     "Date": DateType,
     "DateTime": DateTimeType,
     "DateTime64": DateTime64Type,
@@ -879,7 +1330,7 @@ cdef dict CH_TYPES_MAPPING = {
 }
 
 
-cdef what_py_type(str name, bint container = False):
+cpdef what_py_type(str name, bint container = False):
     """ Returns needed type class from clickhouse type name """
     name = name.strip()
     try:

--- a/aiochclient/binary.py
+++ b/aiochclient/binary.py
@@ -18,9 +18,14 @@ from aiochclient.records import Record, record_from_decoded
 # whole-row reader that avoids per-value Python dispatch) when the Cython
 # extension is built, falling back to the pure-Python implementations.
 try:
-    from aiochclient._types import Cursor, read_row as _read_row_native, what_py_type
+    from aiochclient._types import (
+        Cursor,
+        read_column,
+        read_row as _read_row_native,
+        what_py_type,
+    )
 except ImportError:
-    from aiochclient.types import Cursor, what_py_type
+    from aiochclient.types import Cursor, read_column, what_py_type
 
     _read_row_native = None
 

--- a/aiochclient/binary.py
+++ b/aiochclient/binary.py
@@ -11,66 +11,41 @@ methods synchronous and fast).
 
 from typing import Any, AsyncGenerator, Callable, List
 
+from aiochclient.exceptions import NeedMoreData
 from aiochclient.records import Record
 
-# The RowBinary read path uses the pure-Python type objects, which carry the
-# ``read`` methods. (The Cython mirror of ``read`` lands in a later phase.)
+# The type objects carry the read/write logic (pure Python). The hot per-value
+# buffer access goes through the compiled Cursor when the Cython extension is
+# available, falling back to the pure-Python Cursor otherwise.
 from aiochclient.types import what_py_type
 
-
-class NeedMoreData(Exception):
-    """Raised by ``Cursor`` when the buffer does not hold the requested bytes."""
-
-
-class Cursor:
-    """Synchronous forward cursor over a bytes buffer."""
-
-    __slots__ = ("buf", "pos")
-
-    def __init__(self, buf: bytes = b""):
-        self.buf = buf
-        self.pos = 0
-
-    def read(self, n: int) -> bytes:
-        end = self.pos + n
-        if end > len(self.buf):
-            raise NeedMoreData
-        chunk = self.buf[self.pos : end]
-        self.pos = end
-        return chunk
-
-    def read_varint(self) -> int:
-        buf = self.buf
-        size = len(buf)
-        pos = self.pos
-        result = 0
-        shift = 0
-        while True:
-            if pos >= size:
-                raise NeedMoreData
-            byte = buf[pos]
-            pos += 1
-            result |= (byte & 0x7F) << shift
-            if not byte & 0x80:
-                self.pos = pos
-                return result
-            shift += 7
+try:
+    from aiochclient._types import Cursor
+except ImportError:
+    from aiochclient.types import Cursor
 
 
-def read_binary_str(cursor: Cursor) -> bytes:
+def read_binary_str(cursor) -> bytes:
     """Read a length-prefixed (LEB128) byte string."""
     length = cursor.read_varint()
     return cursor.read(length)
 
 
 class BinaryReader:
-    """Buffers an async stream of chunks and runs synchronous parsers over it."""
+    """Buffers an async stream of chunks and runs synchronous parsers over it.
 
-    __slots__ = ("_source", "buf", "_exhausted")
+    A committed position advances through the buffer as items are parsed (no
+    per-item slicing — that would be quadratic on a large result). The consumed
+    prefix is dropped only when more data has to be fetched, which keeps memory
+    bounded for streaming without copying on the hot path.
+    """
+
+    __slots__ = ("_source", "_buf", "_pos", "_exhausted")
 
     def __init__(self, source: AsyncGenerator[bytes, None]):
         self._source = source.__aiter__()
-        self.buf = b""
+        self._buf = b""
+        self._pos = 0
         self._exhausted = False
 
     async def _more(self) -> bool:
@@ -81,26 +56,30 @@ class BinaryReader:
         except StopAsyncIteration:
             self._exhausted = True
             return False
-        self.buf += chunk
+        # Drop the already-consumed prefix before growing the buffer.
+        if self._pos:
+            self._buf = self._buf[self._pos :]
+            self._pos = 0
+        self._buf += chunk
         return True
 
     async def parse(self, fn: Callable[[Cursor], Any]) -> Any:
         """Run ``fn(cursor)``, refilling the buffer on ``NeedMoreData``."""
         while True:
-            cursor = Cursor(self.buf)
+            cursor = Cursor(self._buf, self._pos)
             try:
                 result = fn(cursor)
             except NeedMoreData:
                 if not await self._more():
                     raise
                 continue
-            self.buf = self.buf[cursor.pos :]
+            self._pos = cursor.pos
             return result
 
 
 async def _read_header(reader: BinaryReader):
     """Read a RowBinaryWithNamesAndTypes header -> (names, type strings)."""
-    num_columns = await reader.parse(Cursor.read_varint)
+    num_columns = await reader.parse(lambda cursor: cursor.read_varint())
     names = [(await reader.parse(read_binary_str)).decode() for _ in range(num_columns)]
     types = [(await reader.parse(read_binary_str)).decode() for _ in range(num_columns)]
     return names, types

--- a/aiochclient/binary.py
+++ b/aiochclient/binary.py
@@ -14,15 +14,15 @@ from typing import Any, AsyncGenerator, Callable, List
 from aiochclient.exceptions import NeedMoreData
 from aiochclient.records import Record
 
-# The type objects carry the read/write logic (pure Python). The hot per-value
-# buffer access goes through the compiled Cursor when the Cython extension is
-# available, falling back to the pure-Python Cursor otherwise.
-from aiochclient.types import what_py_type
-
+# Use the compiled engine (Cursor, type objects with C-level read/write, and a
+# whole-row reader that avoids per-value Python dispatch) when the Cython
+# extension is built, falling back to the pure-Python implementations.
 try:
-    from aiochclient._types import Cursor
+    from aiochclient._types import Cursor, read_row as _read_row_native, what_py_type
 except ImportError:
-    from aiochclient.types import Cursor
+    from aiochclient.types import Cursor, what_py_type
+
+    _read_row_native = None
 
 
 def read_binary_str(cursor) -> bytes:
@@ -109,20 +109,17 @@ def rows_to_binary(rows, types: list) -> bytes:
 class RowBinaryFabric:
     """Builds :class:`Record` objects from RowBinary rows."""
 
-    __slots__ = ("names", "readers", "_read_row")
+    __slots__ = ("names", "types")
 
-    def __init__(self, names: List[str], types: List[str], convert: bool = True):
+    def __init__(self, names: List[str], types: List[str]):
         self.names = {name: index for index, name in enumerate(names)}
-        readers = [what_py_type(tp).read for tp in types]
-        self.readers = readers
-
-        def _read_row(cursor: Cursor) -> tuple:
-            return tuple(read(cursor) for read in readers)
-
-        self._read_row = _read_row
+        self.types = tuple(what_py_type(tp) for tp in types)
 
     def read_row(self, cursor: Cursor) -> tuple:
-        return self._read_row(cursor)
+        if _read_row_native is not None:
+            # Compiled whole-row read (no per-value Python dispatch).
+            return _read_row_native(cursor, self.types)
+        return tuple(tp.read(cursor) for tp in self.types)
 
     def new(self, values: tuple) -> Record:
         return Record.from_decoded(values, self.names)

--- a/aiochclient/binary.py
+++ b/aiochclient/binary.py
@@ -12,7 +12,7 @@ methods synchronous and fast).
 from typing import Any, AsyncGenerator, Callable, List
 
 from aiochclient.exceptions import NeedMoreData
-from aiochclient.records import Record
+from aiochclient.records import Record, record_from_decoded
 
 # Use the compiled engine (Cursor, type objects with C-level read/write, and a
 # whole-row reader that avoids per-value Python dispatch) when the Cython
@@ -122,7 +122,7 @@ class RowBinaryFabric:
         return tuple(tp.read(cursor) for tp in self.types)
 
     def new(self, values: tuple) -> Record:
-        return Record.from_decoded(values, self.names)
+        return record_from_decoded(values, self.names)
 
 
 async def rows_from_binary(

--- a/aiochclient/binary.py
+++ b/aiochclient/binary.py
@@ -104,6 +104,16 @@ async def fetch_column_types(source: AsyncGenerator[bytes, None]) -> list:
     return [what_py_type(tp) for tp in types]
 
 
+async def fetch_column_header(source: AsyncGenerator[bytes, None]):
+    """Read a (LIMIT 0) RowBinaryWithNamesAndTypes header -> (names, type strings).
+
+    The Native INSERT block needs the column names and raw type strings (not the
+    parsed type objects), so this returns the header verbatim.
+    """
+    reader = BinaryReader(source)
+    return await _read_header(reader)
+
+
 def rows_to_binary(rows, types: list) -> bytes:
     """Encode rows (iterables of column values) as a RowBinary body."""
     return b"".join(

--- a/aiochclient/client.py
+++ b/aiochclient/client.py
@@ -6,7 +6,7 @@ from types import TracebackType
 from typing import Any, AsyncGenerator, BinaryIO, Dict, List, Optional, Type
 
 from aiochclient.binary import fetch_column_types, rows_from_binary, rows_to_binary
-from aiochclient.native import rows_from_native
+from aiochclient.native import blocks_from_native, rows_from_native
 from aiochclient.exceptions import ChClientError
 from aiochclient.http_clients.abc import HttpClientABC
 from aiochclient.records import FromJsonFabric, Record, RecordsFabric
@@ -229,6 +229,38 @@ class ChClient:
                 url=self.url, params=params, headers=self.headers, data=data
             )
 
+    def _native_block_stream(
+        self,
+        query: str,
+        params: Optional[Dict[str, Any]],
+        query_id: str,
+    ):
+        """Native-block source for a fetch-style query, or ``None`` if N/A.
+
+        ``fetch`` collects a whole result into a list, so it can consume the
+        Native stream a block at a time and ``list.extend`` each block — keeping
+        the per-row work out of the (much costlier) async-generator protocol.
+        Returns ``None`` for queries that don't fetch in Native (so the caller
+        falls back to the generic row path).
+        """
+        query_params = self._prepare_query_params(params)
+        if query_params:
+            query = query.format(**query_params)
+        need_fetch, is_json, _ = self._parse_squery(query)
+        if not need_fetch or is_json:
+            return None
+        query += " FORMAT Native"
+        request_params = {**self.params}
+        if query_id is not None:
+            request_params["query_id"] = query_id
+        source = self._http_client.post_return_bytes(
+            url=self.url,
+            params=request_params,
+            headers=self.headers,
+            data=query.encode(),
+        )
+        return blocks_from_native(source)
+
     @staticmethod
     def _rowbinary_insert_query(query: str) -> str:
         # Swap the trailing ``VALUES`` for ``FORMAT RowBinary`` so the binary
@@ -328,6 +360,13 @@ class ChClient:
 
         :return: All rows from query.
         """
+        if self._native and not json and not args:
+            blocks = self._native_block_stream(query, params, query_id)
+            if blocks is not None:
+                result: List[Record] = []
+                async for block in blocks:
+                    result.extend(block)
+                return result
         return [
             row
             async for row in self._execute(

--- a/aiochclient/client.py
+++ b/aiochclient/client.py
@@ -6,6 +6,7 @@ from types import TracebackType
 from typing import Any, AsyncGenerator, BinaryIO, Dict, List, Optional, Type
 
 from aiochclient.binary import fetch_column_types, rows_from_binary, rows_to_binary
+from aiochclient.native import rows_from_native
 from aiochclient.exceptions import ChClientError
 from aiochclient.http_clients.abc import HttpClientABC
 from aiochclient.records import FromJsonFabric, Record, RecordsFabric
@@ -67,6 +68,7 @@ class ChClient:
         "_json",
         "_http_client",
         "_binary",
+        "_native",
     )
 
     def __init__(
@@ -79,6 +81,7 @@ class ChClient:
         compress_response: bool = False,
         json=json_,  # type: ignore
         binary: bool = False,
+        native: bool = False,
         **settings,
     ):
         _http_client = HttpClientABC.choose_http_client(session)
@@ -95,8 +98,9 @@ class ChClient:
         if compress_response:
             self.params["enable_http_compression"] = 1
         self._json = json
-        # Decode SELECT results with the RowBinary engine instead of TSV.
+        # Decode SELECT results with the RowBinary / Native engine instead of TSV.
         self._binary = binary
+        self._native = native
         self.params.update(settings)
 
     async def __aenter__(self) -> 'ChClient':
@@ -165,7 +169,9 @@ class ChClient:
             is_json = True
 
         if not is_json and need_fetch:
-            if self._binary:
+            if self._native:
+                query += " FORMAT Native"
+            elif self._binary:
                 query += " FORMAT RowBinaryWithNamesAndTypes"
             else:
                 query += " FORMAT TSVWithNamesAndTypes"
@@ -195,11 +201,12 @@ class ChClient:
             params["query_id"] = query_id
 
         if need_fetch:
-            if self._binary and not is_json:
+            if (self._native or self._binary) and not is_json:
                 source = self._http_client.post_return_bytes(
                     url=self.url, params=params, headers=self.headers, data=data
                 )
-                async for record in rows_from_binary(source):
+                driver = rows_from_native if self._native else rows_from_binary
+                async for record in driver(source):
                     yield record
                 return
             response = self._http_client.post_return_lines(

--- a/aiochclient/client.py
+++ b/aiochclient/client.py
@@ -5,8 +5,13 @@ from enum import Enum
 from types import TracebackType
 from typing import Any, AsyncGenerator, BinaryIO, Dict, List, Optional, Type
 
-from aiochclient.binary import fetch_column_types, rows_from_binary, rows_to_binary
-from aiochclient.native import blocks_from_native, rows_from_native
+from aiochclient.binary import (
+    fetch_column_header,
+    fetch_column_types,
+    rows_from_binary,
+    rows_to_binary,
+)
+from aiochclient.native import blocks_from_native, rows_from_native, rows_to_native
 from aiochclient.exceptions import ChClientError
 from aiochclient.http_clients.abc import HttpClientABC
 from aiochclient.records import FromJsonFabric, Record, RecordsFabric
@@ -182,11 +187,17 @@ class ChClient:
                     "It is possible to pass arguments only for INSERT queries"
                 )
 
-            if self._binary and not is_json:
+            if self._native and not is_json:
+                # Encode the rows column-by-column into a single Native block,
+                # using the target column names and types.
+                names, types = await self._fetch_insert_column_header(query)
+                query = self._columnar_insert_query(query, "Native")
+                data = rows_to_native(args, names, types)
+            elif self._binary and not is_json:
                 # RowBinary is type-specific, so fetch the target column types
                 # and encode the rows to match them exactly.
                 types = await self._fetch_insert_column_types(query)
-                query = self._rowbinary_insert_query(query)
+                query = self._columnar_insert_query(query, "RowBinary")
                 data = rows_to_binary(args, types)
             elif is_json:
                 data = json2ch(*args, dumps=self._json.dumps)
@@ -262,15 +273,15 @@ class ChClient:
         return blocks_from_native(source)
 
     @staticmethod
-    def _rowbinary_insert_query(query: str) -> str:
-        # Swap the trailing ``VALUES`` for ``FORMAT RowBinary`` so the binary
-        # body is parsed as RowBinary rather than VALUES tuples.
+    def _columnar_insert_query(query: str, fmt: str) -> str:
+        # Swap the trailing ``VALUES`` for ``FORMAT <fmt>`` so the binary body is
+        # parsed as RowBinary/Native rather than as VALUES tuples.
         head = re.sub(r"\s+VALUES\b.*$", "", query, flags=re.IGNORECASE | re.DOTALL)
-        return head.rstrip() + " FORMAT RowBinary"
+        return head.rstrip() + f" FORMAT {fmt}"
 
-    async def _fetch_insert_column_types(self, query: str) -> list:
-        # RowBinary encoding depends on the exact column types, so look them up
-        # from the target table (in the order the INSERT lists them).
+    def _insert_column_probe(self, query: str):
+        # Look up the target columns (in the order the INSERT lists them) via a
+        # LIMIT 0 probe; the header carries their names and exact types.
         match = re.match(
             r"\s*INSERT\s+INTO\s+(?P<table>[^\s(]+)\s*(?:\((?P<cols>[^)]*)\))?",
             query,
@@ -283,13 +294,18 @@ class ChClient:
             f"SELECT {cols.strip() if cols else '*'} "
             f"FROM {match.group('table')} LIMIT 0 FORMAT RowBinaryWithNamesAndTypes"
         )
-        source = self._http_client.post_return_bytes(
+        return self._http_client.post_return_bytes(
             url=self.url,
             params={**self.params},
             headers=self.headers,
             data=probe.encode(),
         )
-        return await fetch_column_types(source)
+
+    async def _fetch_insert_column_types(self, query: str) -> list:
+        return await fetch_column_types(self._insert_column_probe(query))
+
+    async def _fetch_insert_column_header(self, query: str):
+        return await fetch_column_header(self._insert_column_probe(query))
 
     async def execute(
         self,

--- a/aiochclient/exceptions.py
+++ b/aiochclient/exceptions.py
@@ -7,3 +7,7 @@ class ChClientError(Exception):
 
     - Clickhouse returns some errors.
     """
+
+
+class NeedMoreData(Exception):
+    """Internal signal: a RowBinary cursor ran out of buffered bytes."""

--- a/aiochclient/native.py
+++ b/aiochclient/native.py
@@ -9,8 +9,13 @@ one, which is what lets this engine rival the columnar C clients without numpy.
 """
 
 import array
+import datetime as dt
+import re
 import sys
+from decimal import Decimal
+from ipaddress import IPv4Address, IPv6Address
 from typing import AsyncGenerator
+from uuid import UUID
 
 from aiochclient.binary import (
     BinaryReader,
@@ -275,3 +280,177 @@ async def rows_from_native(
     async for block in blocks_from_native(source):
         for record in block:
             yield record
+
+
+# --------------------------------------------------------------------------- #
+# Native INSERT (columnar write path)
+# --------------------------------------------------------------------------- #
+
+# Epochs for the null-slot defaults below.
+_EPOCH_DATE = dt.date(1970, 1, 1)
+_EPOCH_DATETIME = dt.datetime(1970, 1, 1)
+
+
+def _write_varint(value):
+    """Encode an unsigned int as LEB128 (the Native length prefix)."""
+    out = bytearray()
+    while True:
+        byte = value & 0x7F
+        value >>= 7
+        if value:
+            out.append(byte | 0x80)
+        else:
+            out.append(byte)
+            return bytes(out)
+
+
+def _write_str(value):
+    encoded = value.encode()
+    return _write_varint(len(encoded)) + encoded
+
+
+def _wire_type(ctype):
+    """Map a column type to the type declared (and encoded) in an INSERT block.
+
+    ClickHouse converts an INSERT block's columns to the table's types, so the
+    dictionary-encoded LowCardinality and the Nested sugar do not need to be
+    written natively: LowCardinality(T) is sent as T, and Nested(...) as the
+    Array(Tuple(...)) it is stored as. Containers are rewritten recursively.
+    """
+    if ctype.startswith("LowCardinality("):
+        return _wire_type(ctype[15:-1])
+    if ctype.startswith("Nested("):
+        return _wire_type("Array(Tuple(" + ctype[7:-1] + "))")
+    if ctype.startswith("Nullable("):
+        return "Nullable(" + _wire_type(ctype[9:-1]) + ")"
+    if ctype.startswith("Array("):
+        return "Array(" + _wire_type(ctype[6:-1]) + ")"
+    if ctype.startswith("Map("):
+        ktype, vtype = _split_args(ctype[4:-1])
+        return "Map(" + _wire_type(ktype) + ", " + _wire_type(vtype) + ")"
+    if ctype.startswith("Tuple("):
+        return (
+            "Tuple("
+            + ", ".join(_wire_element(s) for s in _split_args(ctype[6:-1]))
+            + ")"
+        )
+    return ctype
+
+
+def _wire_element(spec):
+    """Rewrite one (possibly ``name Type``) Tuple element to its wire form."""
+    etype = _element_type(spec)
+    if etype == spec:
+        return _wire_type(spec)
+    name = spec[: len(spec) - len(etype)].rstrip()
+    return name + " " + _wire_type(etype)
+
+
+def _zero_value(ctype):
+    """A valid default for an inner type, used to fill NULL slots.
+
+    In a Native Nullable column every row carries a value (the null map decides
+    which are NULL), so NULL positions still need encodable bytes; the value
+    itself is discarded on read.
+    """
+    if ctype.startswith("Array("):
+        return []
+    if ctype.startswith("Map("):
+        return {}
+    if ctype.startswith("Tuple("):
+        return tuple(_zero_value(_element_type(s)) for s in _split_args(ctype[6:-1]))
+    if ctype.startswith("Float"):
+        return 0.0
+    if ctype == "String" or ctype.startswith("FixedString"):
+        return ""
+    if ctype == "Bool":
+        return False
+    if ctype.startswith("DateTime"):
+        return _EPOCH_DATETIME
+    if ctype.startswith("Date"):
+        return _EPOCH_DATE
+    if ctype.startswith("Decimal"):
+        return Decimal(0)
+    if ctype == "UUID":
+        return UUID(int=0)
+    if ctype.startswith("IPv4"):
+        return IPv4Address(0)
+    if ctype.startswith("IPv6"):
+        return IPv6Address(0)
+    if ctype.startswith("Enum"):
+        match = re.search(r"'((?:[^'\\]|\\.)*)'", ctype)
+        return match.group(1) if match else ""
+    return 0  # Int/UInt of any width
+
+
+def _fill_nulls(values, inner):
+    """Replace None with a placeholder for the Nullable values sub-column."""
+    sample = next((v for v in values if v is not None), None)
+    if sample is None:
+        sample = _zero_value(inner)
+    return [sample if v is None else v for v in values]
+
+
+def encode_column(values, ctype):
+    """Encode a list of ``values`` as one Native column body of type ``ctype``."""
+    spec = _NUMERIC.get(ctype)
+    if spec is not None:
+        column = array.array(spec[0], values)
+        if not _LE:
+            column.byteswap()
+        return column.tobytes()
+    if ctype.startswith("Nullable("):
+        inner = ctype[9:-1]
+        flags = bytes(1 if v is None else 0 for v in values)
+        return flags + encode_column(_fill_nulls(values, inner), inner)
+    if ctype.startswith("Array("):
+        inner = ctype[6:-1]
+        offsets = array.array("Q")
+        flat = []
+        total = 0
+        for value in values:
+            total += len(value)
+            offsets.append(total)
+            flat.extend(value)
+        if not _LE:
+            offsets.byteswap()
+        return offsets.tobytes() + encode_column(flat, inner)
+    if ctype.startswith("Tuple("):
+        specs = [_element_type(s) for s in _split_args(ctype[6:-1])]
+        return b"".join(
+            encode_column([row[i] for row in values], etype)
+            for i, etype in enumerate(specs)
+        )
+    if ctype.startswith("Map("):
+        ktype, vtype = _split_args(ctype[4:-1])
+        offsets = array.array("Q")
+        keys = []
+        vals = []
+        total = 0
+        for mapping in values:
+            total += len(mapping)
+            offsets.append(total)
+            keys.extend(mapping.keys())
+            vals.extend(mapping.values())
+        if not _LE:
+            offsets.byteswap()
+        return (
+            offsets.tobytes() + encode_column(keys, ktype) + encode_column(vals, vtype)
+        )
+    # Scalar fallback: a Native column is its RowBinary per-value writes back to
+    # back (numerics excepted above for the array fast path).
+    writer = what_py_type(ctype)
+    return b"".join(writer.write(value) for value in values)
+
+
+def rows_to_native(rows, names, types):
+    """Encode ``rows`` (iterables of column values) as a single Native block."""
+    rows = [tuple(row) for row in rows]
+    wire_types = [_wire_type(t) for t in types]
+    parts = [_write_varint(len(names)), _write_varint(len(rows))]
+    columns = list(zip(*rows)) if rows else [() for _ in names]
+    for name, wire_type, column in zip(names, wire_types, columns):
+        parts.append(_write_str(name))
+        parts.append(_write_str(wire_type))
+        parts.append(encode_column(list(column), wire_type))
+    return b"".join(parts)

--- a/aiochclient/native.py
+++ b/aiochclient/native.py
@@ -1,0 +1,118 @@
+"""Native (columnar) decoding engine.
+
+ClickHouse's ``Native`` format is column-oriented: a stream of blocks, each a
+``varint(num_columns), varint(num_rows)`` header followed, per column, by its
+name, type and the ``num_rows`` values laid out contiguously. Decoding a whole
+column at once — fixed-width numerics via the stdlib ``array`` module, strings
+and dates in a compiled Cursor loop — is far cheaper than reading values one by
+one, which is what lets this engine rival the columnar C clients without numpy.
+"""
+
+import array
+import sys
+from typing import AsyncGenerator
+
+from aiochclient.binary import BinaryReader, read_binary_str
+from aiochclient.exceptions import ChClientError, NeedMoreData
+from aiochclient.records import Record
+
+# Use the compiled Cursor (with bulk column reads) when available.
+try:
+    from aiochclient._types import Cursor  # noqa: F401
+except ImportError:
+    from aiochclient.types import Cursor  # noqa: F401
+
+_LE = sys.byteorder == "little"
+
+# Fixed-width ClickHouse numeric type -> (array typecode, byte width).
+_NUMERIC = {
+    "UInt8": ("B", 1),
+    "Int8": ("b", 1),
+    "UInt16": ("H", 2),
+    "Int16": ("h", 2),
+    "UInt32": ("I", 4),
+    "Int32": ("i", 4),
+    "UInt64": ("Q", 8),
+    "Int64": ("q", 8),
+    "Float32": ("f", 4),
+    "Float64": ("d", 8),
+}
+for _t, (_c, _w) in _NUMERIC.items():
+    assert array.array(_c).itemsize == _w, _t  # platform sanity check
+
+
+def decode_column(cursor, n, ctype):
+    """Decode one column of ``n`` values from the cursor."""
+    spec = _NUMERIC.get(ctype)
+    if spec is not None:
+        code, width = spec
+        column = array.array(code)
+        column.frombytes(cursor.read(n * width))
+        if not _LE:
+            column.byteswap()
+        return column.tolist()
+    if ctype == "Bool":
+        return [byte != 0 for byte in cursor.read(n)]
+    if ctype == "String":
+        return cursor.read_string_column(n)
+    if ctype.startswith("FixedString"):
+        width = int(ctype[12:-1])
+        data = cursor.read(n * width)
+        return [data[i * width : (i + 1) * width].decode() for i in range(n)]
+    if ctype == "Date":
+        return cursor.read_date_column(n)
+    if ctype == "DateTime" or ctype.startswith("DateTime("):
+        # The Native format does not carry the per-column timezone (it always
+        # ships the UTC epoch), so DateTime is returned as a naive UTC datetime.
+        # The TSV/RowBinary engines apply the column timezone instead.
+        return cursor.read_datetime_column(n)
+    if ctype.startswith("Nullable("):
+        inner = ctype[9:-1]
+        flags = cursor.read(n)
+        values = decode_column(cursor, n, inner)
+        return [None if flags[i] else values[i] for i in range(n)]
+    if ctype.startswith("Array("):
+        inner = ctype[6:-1]
+        offsets = decode_column(cursor, n, "UInt64")
+        total = offsets[-1] if n else 0
+        flat = decode_column(cursor, total, inner)
+        out = []
+        prev = 0
+        for offset in offsets:
+            out.append(flat[prev:offset])
+            prev = offset
+        return out
+    raise ChClientError(f"Native decoding is not implemented for type '{ctype}'")
+
+
+def _read_varint(cursor):
+    return cursor.read_varint()
+
+
+async def rows_from_native(
+    source: AsyncGenerator[bytes, None],
+) -> AsyncGenerator[Record, None]:
+    """Yield :class:`Record` per row of a ``Native`` stream (block by block)."""
+    reader = BinaryReader(source)
+    while True:
+        try:
+            num_columns = await reader.parse(_read_varint)
+        except NeedMoreData:
+            return  # end of stream
+        num_rows = await reader.parse(_read_varint)
+        names = []
+        columns = []
+        # Each column is laid out as: name, type, then its contiguous values.
+        for _ in range(num_columns):
+            names.append((await reader.parse(read_binary_str)).decode())
+            ctype = (await reader.parse(read_binary_str)).decode()
+            columns.append(
+                await reader.parse(
+                    lambda cursor, ct=ctype, nr=num_rows: decode_column(cursor, nr, ct)
+                )
+            )
+        if not num_rows:
+            continue
+        name_map = {name: index for index, name in enumerate(names)}
+        for values in zip(*columns):
+            yield Record.from_decoded(values, name_map)

--- a/aiochclient/native.py
+++ b/aiochclient/native.py
@@ -46,6 +46,10 @@ for _t, (_c, _w) in _NUMERIC.items():
     assert array.array(_c).itemsize == _w, _t  # platform sanity check
 
 
+# LowCardinality index width: the flags word's low byte selects the key type.
+_LC_INDEX_TYPE = {0: "UInt8", 1: "UInt16", 2: "UInt32", 3: "UInt64"}
+
+
 def _split_args(spec):
     """Split a comma-separated type-argument list at the top level.
 
@@ -99,8 +103,41 @@ def _element_type(spec):
     return spec
 
 
+def _read_prefix(cursor, ctype):
+    """Consume the column's serialization-state prefix.
+
+    Before the column body, ClickHouse writes a UInt64 key-serialization
+    version for every LowCardinality found anywhere in the type tree
+    (depth-first). For a top-level LowCardinality this byte run sits right in
+    front of its body, but inside an Array/Map/Tuple it is hoisted ahead of the
+    offsets — so the prefix must be read as a separate pass over the type tree.
+    """
+    if ctype.startswith("LowCardinality("):
+        cursor.read(8)  # KeysSerializationVersion (always 1)
+        _read_prefix(cursor, ctype[15:-1])
+    elif ctype.startswith("Array("):
+        _read_prefix(cursor, ctype[6:-1])
+    elif ctype.startswith("Nullable("):
+        _read_prefix(cursor, ctype[9:-1])
+    elif ctype.startswith("Nested("):
+        _read_prefix(cursor, "Tuple(" + ctype[7:-1] + ")")
+    elif ctype.startswith("Tuple("):
+        for spec in _split_args(ctype[6:-1]):
+            _read_prefix(cursor, _element_type(spec))
+    elif ctype.startswith("Map("):
+        ktype, vtype = _split_args(ctype[4:-1])
+        _read_prefix(cursor, ktype)
+        _read_prefix(cursor, vtype)
+
+
+def decode_column_with_prefix(cursor, n, ctype):
+    """Read a whole top-level column: its state prefix, then its body."""
+    _read_prefix(cursor, ctype)
+    return decode_column(cursor, n, ctype)
+
+
 def decode_column(cursor, n, ctype):
-    """Decode one column of ``n`` values from the cursor."""
+    """Decode the body of one column of ``n`` values from the cursor."""
     spec = _NUMERIC.get(ctype)
     if spec is not None:
         code, width = spec
@@ -160,11 +197,31 @@ def decode_column(cursor, n, ctype):
             out.append(dict(zip(keys[prev:offset], values[prev:offset])))
             prev = offset
         return out
-    if ctype.startswith("LowCardinality(") or ctype.startswith("Nested("):
-        raise ChClientError(
-            f"Native decoding is not yet implemented for type '{ctype}' "
-            f"(use binary=True or the default TSV engine)"
-        )
+    if ctype.startswith("LowCardinality("):
+        # Per block, a LowCardinality column is: a UInt64 key-serialization
+        # version, a UInt64 flags word (its low byte selects the index width),
+        # the dictionary (a UInt64 size then that many inner values), and finally
+        # a UInt64 index count and that many indexes into the dictionary.
+        inner = ctype[15:-1]
+        nullable = inner.startswith("Nullable(")
+        dict_type = inner[9:-1] if nullable else inner
+        # The UInt64 key-serialization version was already consumed by the
+        # column's prefix pass (see _read_prefix); the body starts at the flags.
+        flags = int.from_bytes(cursor.read(8), "little")
+        index_type = _LC_INDEX_TYPE[flags & 0xFF]
+        dict_size = int.from_bytes(cursor.read(8), "little")
+        dictionary = decode_column(cursor, dict_size, dict_type)
+        num_keys = int.from_bytes(cursor.read(8), "little")
+        indexes = decode_column(cursor, num_keys, index_type)
+        if nullable:
+            # Index 0 is reserved for NULL (its dictionary slot is a placeholder).
+            return [None if i == 0 else dictionary[i] for i in indexes]
+        return [dictionary[i] for i in indexes]
+    if ctype.startswith("Nested("):
+        # With flatten_nested=0 a Nested column is laid out exactly like
+        # Array(Tuple(...)) of its sub-fields (shared offsets, then each field
+        # as a flat sub-column), so decode it as such.
+        return decode_column(cursor, n, "Array(Tuple(" + ctype[7:-1] + "))")
     # Generic per-value fallback through the compiled RowBinary readers — covers
     # Decimal, DateTime64, Enum, UUID, IPv4/6, Int128/256 and any other
     # fixed-layout scalar whose Native column is its RowBinary values back to back.
@@ -200,7 +257,9 @@ async def blocks_from_native(
             ctype = (await reader.parse(read_binary_str)).decode()
             columns.append(
                 await reader.parse(
-                    lambda cursor, ct=ctype, nr=num_rows: decode_column(cursor, nr, ct)
+                    lambda cursor, ct=ctype, nr=num_rows: decode_column_with_prefix(
+                        cursor, nr, ct
+                    )
                 )
             )
         if not num_rows:

--- a/aiochclient/native.py
+++ b/aiochclient/native.py
@@ -14,7 +14,7 @@ from typing import AsyncGenerator
 
 from aiochclient.binary import BinaryReader, read_binary_str
 from aiochclient.exceptions import ChClientError, NeedMoreData
-from aiochclient.records import Record
+from aiochclient.records import Record, record_from_decoded
 
 # Use the compiled Cursor (with bulk column reads) when available.
 try:
@@ -89,10 +89,16 @@ def _read_varint(cursor):
     return cursor.read_varint()
 
 
-async def rows_from_native(
+async def blocks_from_native(
     source: AsyncGenerator[bytes, None],
-) -> AsyncGenerator[Record, None]:
-    """Yield :class:`Record` per row of a ``Native`` stream (block by block)."""
+) -> AsyncGenerator[list, None]:
+    """Yield one list of :class:`Record` per ``Native`` block.
+
+    Decoding (and building the rows for) a whole block at once, then handing the
+    list back in a single ``async`` step, avoids pulling 10000s of rows one by
+    one through the async-generator protocol — that per-item cost otherwise
+    roughly halves throughput versus the raw columnar decode.
+    """
     reader = BinaryReader(source)
     while True:
         try:
@@ -114,5 +120,13 @@ async def rows_from_native(
         if not num_rows:
             continue
         name_map = {name: index for index, name in enumerate(names)}
-        for values in zip(*columns):
-            yield Record.from_decoded(values, name_map)
+        yield [record_from_decoded(values, name_map) for values in zip(*columns)]
+
+
+async def rows_from_native(
+    source: AsyncGenerator[bytes, None],
+) -> AsyncGenerator[Record, None]:
+    """Yield :class:`Record` per row of a ``Native`` stream."""
+    async for block in blocks_from_native(source):
+        for record in block:
+            yield record

--- a/aiochclient/native.py
+++ b/aiochclient/native.py
@@ -12,7 +12,12 @@ import array
 import sys
 from typing import AsyncGenerator
 
-from aiochclient.binary import BinaryReader, read_binary_str
+from aiochclient.binary import (
+    BinaryReader,
+    read_binary_str,
+    read_column,
+    what_py_type,
+)
 from aiochclient.exceptions import ChClientError, NeedMoreData
 from aiochclient.records import Record, record_from_decoded
 
@@ -39,6 +44,59 @@ _NUMERIC = {
 }
 for _t, (_c, _w) in _NUMERIC.items():
     assert array.array(_c).itemsize == _w, _t  # platform sanity check
+
+
+def _split_args(spec):
+    """Split a comma-separated type-argument list at the top level.
+
+    Commas inside nested parentheses or single-quoted literals (e.g. an
+    ``Enum8('a'=1,'b'=2)`` element) are not split points.
+    """
+    parts = []
+    depth = 0
+    in_quote = False
+    start = 0
+    i = 0
+    length = len(spec)
+    while i < length:
+        ch = spec[i]
+        if in_quote:
+            if ch == "\\":
+                i += 2
+                continue
+            if ch == "'":
+                in_quote = False
+        elif ch == "'":
+            in_quote = True
+        elif ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+        elif ch == "," and depth == 0:
+            parts.append(spec[start:i].strip())
+            start = i + 1
+        i += 1
+    parts.append(spec[start:].strip())
+    return parts
+
+
+def _element_type(spec):
+    """Strip an optional leading ``name `` from a (possibly named) Tuple element."""
+    depth = 0
+    in_quote = False
+    for i, ch in enumerate(spec):
+        if in_quote:
+            if ch == "'":
+                in_quote = False
+        elif ch == "'":
+            in_quote = True
+        elif ch == "(":
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+        elif ch == " " and depth == 0:
+            return spec[i + 1 :].strip()
+    return spec
 
 
 def decode_column(cursor, n, ctype):
@@ -82,7 +140,35 @@ def decode_column(cursor, n, ctype):
             out.append(flat[prev:offset])
             prev = offset
         return out
-    raise ChClientError(f"Native decoding is not implemented for type '{ctype}'")
+    if ctype.startswith("Tuple("):
+        # Native stores a Tuple column as one sub-column per element.
+        specs = _split_args(ctype[6:-1])
+        subcolumns = [decode_column(cursor, n, _element_type(s)) for s in specs]
+        if not subcolumns:
+            return [() for _ in range(n)]
+        return list(zip(*subcolumns))
+    if ctype.startswith("Map("):
+        # Like Array(Tuple(K, V)): offsets, then a key and a value sub-column.
+        ktype, vtype = _split_args(ctype[4:-1])
+        offsets = decode_column(cursor, n, "UInt64")
+        total = offsets[-1] if n else 0
+        keys = decode_column(cursor, total, ktype)
+        values = decode_column(cursor, total, vtype)
+        out = []
+        prev = 0
+        for offset in offsets:
+            out.append(dict(zip(keys[prev:offset], values[prev:offset])))
+            prev = offset
+        return out
+    if ctype.startswith("LowCardinality(") or ctype.startswith("Nested("):
+        raise ChClientError(
+            f"Native decoding is not yet implemented for type '{ctype}' "
+            f"(use binary=True or the default TSV engine)"
+        )
+    # Generic per-value fallback through the compiled RowBinary readers — covers
+    # Decimal, DateTime64, Enum, UUID, IPv4/6, Int128/256 and any other
+    # fixed-layout scalar whose Native column is its RowBinary values back to back.
+    return read_column(cursor, what_py_type(ctype), n)
 
 
 def _read_varint(cursor):

--- a/aiochclient/records.py
+++ b/aiochclient/records.py
@@ -1,94 +1,105 @@
 from collections.abc import Mapping
 from typing import Any, Callable, Dict, Iterator, List, Tuple, Union
 
-# Optional cython extension:
+# Optional cython extension. When available it also provides a compiled Record
+# (much cheaper to instantiate) and the matching ``record_from_decoded`` factory.
 try:
-    from aiochclient._types import empty_convertor, what_py_converter
+    from aiochclient._types import (
+        Record,
+        empty_convertor,
+        record_new as record_from_decoded,
+        what_py_converter,
+    )
 except ImportError:
     from aiochclient.types import empty_convertor, what_py_converter
 
-__all__ = ["RecordsFabric", "Record", "FromJsonFabric"]
+    class Record(Mapping):
+        """Lightweight, memory efficient objects with full mapping interface,
+        where you can get fields by names or by indexes.
 
+        Usage:
 
-class Record(Mapping):
-    """Lightweight, memory efficient objects with full mapping interface, where
-    you can get fields by names or by indexes.
+        .. code-block:: python
 
-    Usage:
+            row = await client.fetchrow("SELECT a, b FROM t WHERE a=1")
 
-    .. code-block:: python
+            assert row["a"] == 1
+            assert row[0] == 1
+            assert row[:] == (1, (dt.date(2018, 9, 8), 3.14))
+            assert list(row.keys()) == ["a", "b"]
+            assert list(row.values()) == [1, (dt.date(2018, 9, 8), 3.14)]
 
-        row = await client.fetchrow("SELECT a, b FROM t WHERE a=1")
+        """
 
-        assert row["a"] == 1
-        assert row[0] == 1
-        assert row[:] == (1, (dt.date(2018, 9, 8), 3.14))
-        assert list(row.keys()) == ["a", "b"]
-        assert list(row.values()) == [1, (dt.date(2018, 9, 8), 3.14)]
+        __slots__ = ("_converters", "_decoded", "_names", "_row")
 
-    """
+        def __init__(
+            self, row: bytes, names: Dict[str, Any], converters: List[Callable]
+        ):
+            self._row: Union[bytes, Tuple[Any]] = row
+            if not self._row:
+                # in case of empty row
+                self._decoded = True
+                self._converters = []
+                self._names = {}
+            else:
+                self._decoded = False
+                self._converters = converters
+                self._names = names
 
-    __slots__ = ("_converters", "_decoded", "_names", "_row")
+        @classmethod
+        def from_decoded(cls, values: Tuple[Any], names: Dict[str, Any]) -> "Record":
+            """Build a record from already-decoded values (binary/native path)."""
+            record = cls.__new__(cls)
+            record._row = values
+            record._decoded = True
+            record._converters = None
+            record._names = names
+            return record
 
-    def __init__(self, row: bytes, names: Dict[str, Any], converters: List[Callable]):
-        self._row: Union[bytes, Tuple[Any]] = row
-        if not self._row:
-            # in case of empty row
-            self._decoded = True
-            self._converters = []
-            self._names = {}
-        else:
-            self._decoded = False
-            self._converters = converters
-            self._names = names
+        def __getitem__(self, key: Union[str, int, slice]) -> Any:
+            self._decode()
+            return self._getitem(key)
 
-    @classmethod
-    def from_decoded(cls, values: Tuple[Any], names: Dict[str, Any]) -> "Record":
-        """Build a record from already-decoded values (RowBinary path)."""
-        record = cls.__new__(cls)
-        record._row = values
-        record._decoded = True
-        record._converters = []
-        record._names = names
-        return record
-
-    def __getitem__(self, key: Union[str, int, slice]) -> Any:
-        self._decode()
-        return self._getitem(key)
-
-    def _getitem(self, key: Union[str, int, slice]) -> Any:
-        if type(key) == str:
+        def _getitem(self, key: Union[str, int, slice]) -> Any:
+            if type(key) == str:
+                try:
+                    return self._row[self._names[key]]
+                except KeyError:
+                    if not self._row:
+                        raise KeyError(
+                            "Empty row. May be it is result of 'WITH TOTALS' query."
+                        )
+                    raise KeyError(f"No fields with name '{key}'")
             try:
-                return self._row[self._names[key]]
-            except KeyError:
+                return self._row[key]
+            except IndexError:
                 if not self._row:
-                    raise KeyError(
+                    raise IndexError(
                         "Empty row. May be it is result of 'WITH TOTALS' query."
                     )
-                raise KeyError(f"No fields with name '{key}'")
-        try:
-            return self._row[key]
-        except IndexError:
-            if not self._row:
-                raise IndexError(
-                    "Empty row. May be it is result of 'WITH TOTALS' query."
-                )
-            raise IndexError(f"No fields with index '{key}'")
+                raise IndexError(f"No fields with index '{key}'")
 
-    def __iter__(self) -> Iterator:
-        return iter(self._names)
+        def __iter__(self) -> Iterator:
+            return iter(self._names)
 
-    def __len__(self) -> int:
-        return len(self._names)
+        def __len__(self) -> int:
+            return len(self._names)
 
-    def _decode(self):
-        if self._decoded:
-            return None
-        self._row = tuple(
-            converter(val)
-            for converter, val in zip(self._converters, self._row.split(b"\t"))
-        )
-        self._decoded = True
+        def _decode(self):
+            if self._decoded:
+                return None
+            self._row = tuple(
+                converter(val)
+                for converter, val in zip(self._converters, self._row.split(b"\t"))
+            )
+            self._decoded = True
+
+    def record_from_decoded(values: Tuple[Any], names: Dict[str, Any]) -> Record:
+        return Record.from_decoded(values, names)
+
+
+__all__ = ["RecordsFabric", "Record", "FromJsonFabric", "record_from_decoded"]
 
 
 class RecordsFabric:

--- a/aiochclient/types.py
+++ b/aiochclient/types.py
@@ -45,6 +45,15 @@ class Cursor:
                 return result
             shift += 7
 
+    def read_int(self, size: int, signed: bool) -> int:
+        return int.from_bytes(self.read(size), "little", signed=signed)
+
+    def read_double(self) -> float:
+        return struct.unpack("<d", self.read(8))[0]
+
+    def read_float(self) -> float:
+        return struct.unpack("<f", self.read(4))[0]
+
 
 _TZ_UNSET = object()
 
@@ -298,7 +307,7 @@ class BoolType(BaseType):
         return self.p_type(value.decode())
 
     def read(self, cursor) -> bool:
-        return cursor.read(1) != b"\x00"
+        return cursor.read_int(1, False) != 0
 
     def write(self, value: bool) -> bytes:
         return b"\x01" if value else b"\x00"
@@ -318,7 +327,7 @@ class IntType(BaseType):
 
     def read(self, cursor) -> int:
         size, signed = RB_INT_SPECS[self.name]
-        return int.from_bytes(cursor.read(size), "little", signed=signed)
+        return cursor.read_int(size, signed)
 
     def write(self, value: int) -> bytes:
         size, signed = RB_INT_SPECS[self.name]
@@ -334,8 +343,8 @@ class FloatType(IntType):
 
     def read(self, cursor) -> float:
         if self.name == "Float64":
-            return struct.unpack("<d", cursor.read(8))[0]
-        return struct.unpack("<f", cursor.read(4))[0]
+            return cursor.read_double()
+        return cursor.read_float()
 
     def write(self, value: float) -> bytes:
         if self.name == "Float64":
@@ -362,9 +371,7 @@ class DateType(BaseType):
         return self.p_type(value.decode())
 
     def read(self, cursor) -> dt.date:
-        return RB_EPOCH_DATE + dt.timedelta(
-            days=int.from_bytes(cursor.read(2), "little")
-        )
+        return RB_EPOCH_DATE + dt.timedelta(days=cursor.read_int(2, False))
 
     def write(self, value: dt.date) -> bytes:
         return (value - RB_EPOCH_DATE).days.to_bytes(2, "little")
@@ -402,7 +409,7 @@ class DateTimeType(BaseType):
         return self.p_type(value.decode())
 
     def read(self, cursor) -> dt.datetime:
-        seconds = int.from_bytes(cursor.read(4), "little")
+        seconds = cursor.read_int(4, False)
         zone = self._zone()
         if zone is None:
             return RB_EPOCH_DATETIME + dt.timedelta(seconds=seconds)
@@ -453,7 +460,7 @@ class DateTime64Type(BaseType):
         return self.p_type(value.decode())
 
     def read(self, cursor) -> dt.datetime:
-        ticks = int.from_bytes(cursor.read(8), "little", signed=True)
+        ticks = cursor.read_int(8, True)
         # Python datetime only supports microseconds; truncate finer precision.
         if self._precision <= 6:
             micros = ticks * 10 ** (6 - self._precision)
@@ -524,7 +531,7 @@ class IPv4Type(BaseType):
         return self.p_type(value.decode())
 
     def read(self, cursor) -> IPv4Address:
-        return IPv4Address(int.from_bytes(cursor.read(4), "little"))
+        return IPv4Address(cursor.read_int(4, False))
 
     def write(self, value) -> bytes:
         return int(IPv4Address(value)).to_bytes(4, "little")
@@ -791,8 +798,7 @@ class EnumType(StrType):
         self._reverse = {label: index for index, label in self._mapping.items()}
 
     def read(self, cursor) -> str:
-        index = int.from_bytes(cursor.read(self._size), "little", signed=True)
-        return self._mapping[index]
+        return self._mapping[cursor.read_int(self._size, True)]
 
     def write(self, value: str) -> bytes:
         return self._reverse[value].to_bytes(self._size, "little", signed=True)
@@ -824,7 +830,7 @@ class DecimalType(BaseType):
         return self.p_type(value.decode())
 
     def read(self, cursor) -> Decimal:
-        raw = int.from_bytes(cursor.read(self._size), "little", signed=True)
+        raw = cursor.read_int(self._size, True)
         return Decimal(raw).scaleb(-self._scale)
 
     def write(self, value: Decimal) -> bytes:

--- a/aiochclient/types.py
+++ b/aiochclient/types.py
@@ -124,6 +124,7 @@ def _parse_tz(name: str) -> Optional[str]:
         return name[name.index("'") + 1 : name.rindex("'")].replace("\\", "")
     return None
 
+
 # RowBinary integer specs: name -> (byte width, signed). All little-endian.
 RB_INT_SPECS = {
     "UInt8": (1, False),
@@ -156,6 +157,7 @@ def write_varint(value: int) -> bytes:
         else:
             out.append(byte)
             return bytes(out)
+
 
 try:
     import ciso8601
@@ -713,10 +715,7 @@ class ArrayType(BaseType):
         self.type = what_py_type(RE_ARRAY.findall(name)[0], container=True)
 
     def p_type(self, string: str) -> list:
-        return [
-            self.type.p_type(val)
-            for val in self.seq_parser(string[1:-1])
-        ]
+        return [self.type.p_type(val) for val in self.seq_parser(string[1:-1])]
 
     def convert(self, value: bytes) -> list:
         return self.p_type(value.decode())
@@ -846,9 +845,7 @@ class EnumType(StrType):
         self._size = 1 if name.startswith("Enum8") else 2
         self._mapping = {
             int(num): label
-            for label, num in re.findall(
-                r"'((?:[^'\\]|\\.)*)'\s*=\s*(-?\d+)", name
-            )
+            for label, num in re.findall(r"'((?:[^'\\]|\\.)*)'\s*=\s*(-?\d+)", name)
         }
         self._reverse = {label: index for index, label in self._mapping.items()}
 
@@ -972,6 +969,15 @@ def what_py_type(name: str, container: bool = False) -> BaseType:
 def what_py_converter(name: str, container: bool = False) -> Callable:
     """Returns needed type class from clickhouse type name"""
     return what_py_type(name, container).convert
+
+
+def read_column(cursor, reader, n: int) -> list:
+    """Read n contiguous values of one scalar type (Native column fallback).
+
+    Pure-Python mirror of the compiled ``read_column``: a Native scalar column
+    is its RowBinary per-value encodings laid out back to back.
+    """
+    return [reader.read(cursor) for _ in range(n)]
 
 
 def py2ch(value):

--- a/aiochclient/types.py
+++ b/aiochclient/types.py
@@ -54,6 +54,61 @@ class Cursor:
     def read_float(self) -> float:
         return struct.unpack("<f", self.read(4))[0]
 
+    # -- Native engine: whole-column bulk reads (pure-Python fallback) --
+
+    def read_string_column(self, n: int) -> list:
+        buf = self.buf
+        size = len(buf)
+        pos = self.pos
+        out = []
+        for _ in range(n):
+            length = 0
+            shift = 0
+            while True:
+                if pos >= size:
+                    raise NeedMoreData
+                byte = buf[pos]
+                pos += 1
+                length |= (byte & 0x7F) << shift
+                if not byte & 0x80:
+                    break
+                shift += 7
+            end = pos + length
+            if end > size:
+                raise NeedMoreData
+            out.append(buf[pos:end].decode())
+            pos = end
+        self.pos = pos
+        return out
+
+    def read_date_column(self, n: int) -> list:
+        buf = self.buf
+        pos = self.pos
+        end = pos + n * 2
+        if end > len(buf):
+            raise NeedMoreData
+        out = [
+            RB_EPOCH_DATE
+            + dt.timedelta(days=buf[pos + 2 * i] | (buf[pos + 2 * i + 1] << 8))
+            for i in range(n)
+        ]
+        self.pos = end
+        return out
+
+    def read_datetime_column(self, n: int) -> list:
+        buf = self.buf
+        pos = self.pos
+        end = pos + n * 4
+        if end > len(buf):
+            raise NeedMoreData
+        out = []
+        for i in range(n):
+            p = pos + 4 * i
+            secs = buf[p] | (buf[p + 1] << 8) | (buf[p + 2] << 16) | (buf[p + 3] << 24)
+            out.append(RB_EPOCH_DATETIME + dt.timedelta(seconds=secs))
+        self.pos = end
+        return out
+
 
 _TZ_UNSET = object()
 

--- a/aiochclient/types.py
+++ b/aiochclient/types.py
@@ -8,7 +8,42 @@ from typing import Any, Callable, Generator, List, Optional, Tuple
 from uuid import UUID
 from zoneinfo import ZoneInfo
 
-from aiochclient.exceptions import ChClientError
+from aiochclient.exceptions import ChClientError, NeedMoreData
+
+
+class Cursor:
+    """Synchronous forward cursor over a bytes buffer (RowBinary engine)."""
+
+    __slots__ = ("buf", "pos")
+
+    def __init__(self, buf: bytes = b"", pos: int = 0):
+        self.buf = buf
+        self.pos = pos
+
+    def read(self, n: int) -> bytes:
+        end = self.pos + n
+        if end > len(self.buf):
+            raise NeedMoreData
+        chunk = self.buf[self.pos : end]
+        self.pos = end
+        return chunk
+
+    def read_varint(self) -> int:
+        buf = self.buf
+        size = len(buf)
+        pos = self.pos
+        result = 0
+        shift = 0
+        while True:
+            if pos >= size:
+                raise NeedMoreData
+            byte = buf[pos]
+            pos += 1
+            result |= (byte & 0x7F) << shift
+            if not byte & 0x80:
+                self.pos = pos
+                return result
+            shift += 7
 
 
 _TZ_UNSET = object()

--- a/benchmarks.py
+++ b/benchmarks.py
@@ -43,11 +43,19 @@ import datetime as dt
 import time
 import uuid
 
-import uvloop
-from aioch import Client
 from aiohttp import ClientSession
 
 from aiochclient import ChClient
+
+try:
+    import uvloop
+except ImportError:
+    uvloop = None
+
+try:
+    from aioch import Client
+except ImportError:
+    Client = None
 
 
 def row_data():
@@ -179,16 +187,51 @@ async def bench_selects_aioch_with_decoding(*, retries: int, rows: int):
     print(f"  Speed: {speed} rows/sec")
 
 
+async def bench_formats(*, retries: int, rows: int):
+    """Compare the TSV and RowBinary engines for select-decode and insert."""
+    print("TSV vs RowBinary")
+    one_row = row_data()
+    async with ClientSession() as session:
+        prep = ChClient(session)
+        for label, binary in (("TSV      ", False), ("RowBinary", True)):
+            client = ChClient(session, binary=binary)
+            # SELECT (with full decoding) over a fixed `rows`-row table
+            await prepare_db(prep)
+            await insert_rows(prep, one_row, rows)
+            await client.fetch("SELECT * FROM benchmark_tbl")  # warmup
+            start = time.time()
+            for _ in range(retries):
+                selected = await client.fetch("SELECT * FROM benchmark_tbl")
+                _ = [row[:] for row in selected]
+            sel_speed = int(rows / ((time.time() - start) / retries))
+            # INSERT — clear before each run (not timed) to avoid accumulation
+            insert_total = 0.0
+            for _ in range(retries):
+                await prepare_db(prep)
+                start = time.time()
+                await client.execute(
+                    "INSERT INTO benchmark_tbl VALUES",
+                    *(one_row for _ in range(rows)),
+                )
+                insert_total += time.time() - start
+            ins_speed = int(rows / (insert_total / retries))
+            print(
+                f"  {label}  select-decode: {sel_speed:>8} rows/sec"
+                f" | insert: {ins_speed:>8} rows/sec"
+            )
+
+
 async def main():
     await bench_selects(retries=100, rows=10000)
     await bench_selects_with_decoding(retries=100, rows=10000)
     await bench_inserts(retries=100, rows=10000)
+    await bench_formats(retries=50, rows=10000)
 
-    await bench_selects_aioch_with_decoding(retries=100, rows=10000)
+    if Client is not None:
+        await bench_selects_aioch_with_decoding(retries=100, rows=10000)
 
 
 if __name__ == "__main__":
-    uvloop.install()
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
-    loop.close()
+    if uvloop is not None:
+        uvloop.install()
+    asyncio.run(main())

--- a/benchmarks_vs_libs.py
+++ b/benchmarks_vs_libs.py
@@ -82,12 +82,16 @@ def best_sync(fn):
 
 
 # ---------------------------------------------------------------- aiochclient
-async def bench_aiochclient(binary):
+async def bench_aiochclient(engine):
     async with ClientSession() as session:
         prep = ChClient(session)
         await prep.execute("DROP TABLE IF EXISTS bench_libs")
         await prep.execute(DDL)
-        client = ChClient(session, binary=binary)
+        client = ChClient(
+            session,
+            binary=(engine == "rowbinary"),
+            native=(engine == "native"),
+        )
 
         # INSERT
         async def do_insert():
@@ -199,8 +203,9 @@ async def main():
             print(f"  {label:<32} ERROR: {type(exc).__name__}: {exc}")
 
     print(f"Benchmark: {ROWS} rows, best of {RETRIES} runs\n")
-    await run("aiochclient (HTTP, TSV)", lambda: bench_aiochclient(binary=False))
-    await run("aiochclient (HTTP, RowBinary)", lambda: bench_aiochclient(binary=True))
+    await run("aiochclient (HTTP, TSV)", lambda: bench_aiochclient("tsv"))
+    await run("aiochclient (HTTP, RowBinary)", lambda: bench_aiochclient("rowbinary"))
+    await run("aiochclient (HTTP, Native)", lambda: bench_aiochclient("native"))
     await run("clickhouse-connect (HTTP)", bench_clickhouse_connect)
     await run("asynch (native, async)", bench_asynch)
     await run(

--- a/benchmarks_vs_libs.py
+++ b/benchmarks_vs_libs.py
@@ -1,0 +1,214 @@
+"""Compare aiochclient against the popular Python ClickHouse clients.
+
+Real-world-ish workload: a wide-ish, mixed-type table; fully materialize every
+row on SELECT and bulk-insert rows on INSERT. Throughput is reported as
+rows/sec (best of N sequential runs, single connection, no async fan-out).
+
+Run:  python benchmarks_vs_libs.py
+Needs a ClickHouse server with HTTP (8123) and native (9000) ports.
+"""
+
+import asyncio
+import time
+from datetime import date, datetime
+
+from aiohttp import ClientSession
+
+from aiochclient import ChClient
+
+HTTP_PORT = 8123
+NATIVE_PORT = 9000
+ROWS = 50_000
+RETRIES = 8
+
+DDL = """
+CREATE TABLE bench_libs (
+    id UInt32,
+    value Int64,
+    score Float64,
+    name String,
+    created Date,
+    ts DateTime,
+    tags Array(String),
+    opt Nullable(Int32)
+) ENGINE = Memory
+"""
+COLUMNS = ["id", "value", "score", "name", "created", "ts", "tags", "opt"]
+_DATE = date(2021, 6, 1)
+_TS = datetime(2021, 6, 1, 12, 30, 0)
+
+
+def make_rows(n):
+    return [
+        (
+            i,
+            i * 1000,
+            3.14159,
+            f"name_{i}",
+            _DATE,
+            _TS,
+            ["alpha", "beta", "gamma"],
+            (i if i % 2 else None),
+        )
+        for i in range(n)
+    ]
+
+
+ROWS_DATA = make_rows(ROWS)
+
+
+def speed(seconds):
+    return int(ROWS / seconds)
+
+
+async def best(coro_factory):
+    await coro_factory()  # warmup
+    best_time = float("inf")
+    for _ in range(RETRIES):
+        start = time.perf_counter()
+        await coro_factory()
+        best_time = min(best_time, time.perf_counter() - start)
+    return speed(best_time)
+
+
+def best_sync(fn):
+    fn()  # warmup
+    best_time = float("inf")
+    for _ in range(RETRIES):
+        start = time.perf_counter()
+        fn()
+        best_time = min(best_time, time.perf_counter() - start)
+    return speed(best_time)
+
+
+# ---------------------------------------------------------------- aiochclient
+async def bench_aiochclient(binary):
+    async with ClientSession() as session:
+        prep = ChClient(session)
+        await prep.execute("DROP TABLE IF EXISTS bench_libs")
+        await prep.execute(DDL)
+        client = ChClient(session, binary=binary)
+
+        # INSERT
+        async def do_insert():
+            await prep.execute("TRUNCATE TABLE bench_libs")
+            await client.execute("INSERT INTO bench_libs VALUES", *ROWS_DATA)
+
+        ins = await best(do_insert)
+
+        # SELECT (materialize every row)
+        await prep.execute("TRUNCATE TABLE bench_libs")
+        await client.execute("INSERT INTO bench_libs VALUES", *ROWS_DATA)
+
+        async def do_select():
+            rows = await client.fetch("SELECT * FROM bench_libs")
+            return [row[:] for row in rows]
+
+        sel = await best(do_select)
+        return sel, ins
+
+
+# ----------------------------------------------------------- clickhouse-connect
+async def bench_clickhouse_connect():
+    import clickhouse_connect
+
+    client = await clickhouse_connect.get_async_client(host="localhost", port=HTTP_PORT)
+    await client.command("DROP TABLE IF EXISTS bench_libs")
+    await client.command(DDL)
+
+    async def do_insert():
+        await client.command("TRUNCATE TABLE bench_libs")
+        await client.insert("bench_libs", ROWS_DATA, column_names=COLUMNS)
+
+    ins = await best(do_insert)
+
+    await client.command("TRUNCATE TABLE bench_libs")
+    await client.insert("bench_libs", ROWS_DATA, column_names=COLUMNS)
+
+    async def do_select():
+        return (await client.query("SELECT * FROM bench_libs")).result_rows
+
+    sel = await best(do_select)
+    await client.close()
+    return sel, ins
+
+
+# ----------------------------------------------------------------------- asynch
+async def bench_asynch():
+    import asynch
+
+    conn = asynch.Connection(host="localhost", port=NATIVE_PORT)
+    await conn.connect()
+    async with conn.cursor() as cur:
+        await cur.execute("DROP TABLE IF EXISTS bench_libs")
+        await cur.execute(DDL)
+
+        async def do_insert():
+            await cur.execute("TRUNCATE TABLE bench_libs")
+            await cur.execute("INSERT INTO bench_libs VALUES", ROWS_DATA)
+
+        ins = await best(do_insert)
+
+        await cur.execute("TRUNCATE TABLE bench_libs")
+        await cur.execute("INSERT INTO bench_libs VALUES", ROWS_DATA)
+
+        async def do_select():
+            await cur.execute("SELECT * FROM bench_libs")
+            return await cur.fetchall()
+
+        sel = await best(do_select)
+    await conn.close()
+    return sel, ins
+
+
+# ------------------------------------------------------------- clickhouse-driver
+def bench_clickhouse_driver():
+    from clickhouse_driver import Client
+
+    client = Client(host="localhost", port=NATIVE_PORT)
+    client.execute("DROP TABLE IF EXISTS bench_libs")
+    client.execute(DDL)
+
+    def do_insert():
+        client.execute("TRUNCATE TABLE bench_libs")
+        client.execute("INSERT INTO bench_libs VALUES", ROWS_DATA)
+
+    ins = best_sync(do_insert)
+
+    client.execute("TRUNCATE TABLE bench_libs")
+    client.execute("INSERT INTO bench_libs VALUES", ROWS_DATA)
+
+    def do_select():
+        return client.execute("SELECT * FROM bench_libs")
+
+    sel = best_sync(do_select)
+    client.disconnect()
+    return sel, ins
+
+
+async def main():
+    results = []
+
+    async def run(label, factory):
+        try:
+            sel, ins = await factory()
+            results.append((label, sel, ins))
+            print(f"  {label:<32} select {sel:>8} rows/sec | insert {ins:>8} rows/sec")
+        except Exception as exc:  # noqa: BLE001
+            results.append((label, None, None))
+            print(f"  {label:<32} ERROR: {type(exc).__name__}: {exc}")
+
+    print(f"Benchmark: {ROWS} rows, best of {RETRIES} runs\n")
+    await run("aiochclient (HTTP, TSV)", lambda: bench_aiochclient(binary=False))
+    await run("aiochclient (HTTP, RowBinary)", lambda: bench_aiochclient(binary=True))
+    await run("clickhouse-connect (HTTP)", bench_clickhouse_connect)
+    await run("asynch (native, async)", bench_asynch)
+    await run(
+        "clickhouse-driver (native, sync)",
+        lambda: asyncio.get_event_loop().run_in_executor(None, bench_clickhouse_driver),
+    )
+    return results
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ def read(fname):
 
 setup_opts = dict(
     name='aiochclient',
-    version='2.7.0',
+    version='2.8.0',
     description='Async http clickhouse client for python 3.10+',
     long_description=read('README.md'),
     long_description_content_type="text/markdown",

--- a/tests.py
+++ b/tests.py
@@ -1589,6 +1589,68 @@ class TestRowBinary:
         await binary.execute("DROP TABLE IF EXISTS rb_insert_cols")
 
 
+@pytest.mark.usefixtures("class_chclient")
+class TestNative:
+    # https://github.com/maximdanilchenko/aiochclient/issues/134
+    # The columnar Native read engine (Phase 1: numerics, String, FixedString,
+    # Date, DateTime (UTC), Bool, Nullable, Array).
+    NATIVE_DDL = """
+        CREATE TABLE native_t (
+            id UInt32, big Int64, neg Int16, score Float64, f32 Float32,
+            name String, fixed FixedString(4), created Date, ts DateTime,
+            flag Bool, opt Nullable(Int32), arr Array(UInt32), sarr Array(String)
+        ) ENGINE = Memory
+        """
+
+    def _native_client(self):
+        return ChClient(self.ch._http_client._session, native=True)
+
+    async def test_decode_matches_tsv(self):
+        native = self._native_client()
+        await native.execute("DROP TABLE IF EXISTS native_t")
+        await native.execute(self.NATIVE_DDL)
+        rows = [
+            (
+                i,
+                i * 1_000_000_000,
+                -i,
+                i + 0.5,
+                1.5,
+                f"name {i}",
+                "abcd",
+                dt.date(2021, 6, 1),
+                dt.datetime(2021, 6, 1, 12, 30, 0),
+                bool(i % 2),
+                (i if i % 2 else None),
+                [1, 2, 3],
+                ["alpha", "beta"],
+            )
+            for i in range(5)
+        ]
+        await native.execute("INSERT INTO native_t VALUES", *rows)
+        tsv_rows = [
+            r[:] for r in await self.ch.fetch("SELECT * FROM native_t ORDER BY id")
+        ]
+        bin_rows = [
+            r[:] for r in await native.fetch("SELECT * FROM native_t ORDER BY id")
+        ]
+        assert tsv_rows == bin_rows
+        await native.execute("DROP TABLE IF EXISTS native_t")
+
+    async def test_fetchval_iterate_and_mapping(self):
+        native = self._native_client()
+        assert await native.fetchval("SELECT 7::UInt32") == 7
+        record = await native.fetchrow("SELECT 1 AS a, 'x' AS b")
+        assert record["a"] == 1 and record["b"] == "x" and record[0] == 1
+        rows = [r[0] async for r in native.iterate("SELECT number FROM numbers(3)")]
+        assert rows == [0, 1, 2]
+
+    async def test_unsupported_type_raises(self):
+        native = self._native_client()
+        with pytest.raises(ChClientError):
+            await native.fetchval("SELECT 'b'::Enum8('a' = 1, 'b' = 2)")
+
+
 class TestErrorBody:
     # https://github.com/maximdanilchenko/aiochclient/issues/126
     # A non-200 response with an empty body must still raise a ChClientError

--- a/tests.py
+++ b/tests.py
@@ -261,6 +261,25 @@ def class_chclient(chclient, all_types_db, rows, request):
     request.cls.rows = [tuple(r) for r in cls_rows]
 
 
+@pytest.fixture(params=["tsv", "binary", "native"])
+def class_engine(request, chclient):
+    """Run the decoded type checks against each read engine.
+
+    ``self.engine_ch`` is the client whose decoded output is under test; it
+    shares ``chclient``'s session. The ``tsv`` case reuses ``chclient`` itself.
+    The raw-bytes (``decode=False``) assertions always stay on the TSV client,
+    since that path is TSV-only.
+    """
+    engine = request.param
+    request.cls.engine = engine
+    if engine == "binary":
+        request.cls.engine_ch = ChClient(chclient._http_client._session, binary=True)
+    elif engine == "native":
+        request.cls.engine_ch = ChClient(chclient._http_client._session, native=True)
+    else:
+        request.cls.engine_ch = chclient
+
+
 @pytest.mark.client
 @pytest.mark.usefixtures("class_chclient")
 class TestClient:
@@ -277,13 +296,48 @@ class TestClient:
 
 
 @pytest.mark.types
-@pytest.mark.usefixtures("class_chclient")
+@pytest.mark.usefixtures("class_chclient", "class_engine")
 class TestTypes:
+    # Columns the Native engine cannot decode yet: LowCardinality uses a
+    # dictionary-encoded layout and Nested a columnar one (both phase 3), and
+    # the Native format ships DateTime64 without its timezone (returned as naive
+    # UTC, so it cannot match the tz-aware TSV/RowBinary value).
+    NATIVE_UNSUPPORTED = {
+        "low_cardinality_str",
+        "low_cardinality_nullable_str",
+        "low_cardinality_int",
+        "low_cardinality_date",
+        "low_cardinality_datetime",
+        "array_low_cardinality_string",
+        "nested_int",
+        "nested_str_date",
+        "datetime64",
+    }
+
+    # The binary engines decode Float32 from its exact 4-byte IEEE-754 value,
+    # whereas TSV ships ClickHouse's shorter text rounding (e.g. 23.432 vs
+    # 23.43199920654297). The expected values here are the TSV roundings, so
+    # this column is only comparable on the TSV engine.
+    NON_TSV_REPR = {"float32"}
+
+    def _skip_unsupported(self, field):
+        name = field.strip()
+        if self.engine != "tsv" and name in self.NON_TSV_REPR:
+            pytest.skip(f"'{name}' text rounding is TSV-specific")
+        if self.engine == "native" and name in self.NATIVE_UNSUPPORTED:
+            pytest.skip(f"Native engine does not decode '{name}' yet")
+
     async def select_field(self, field):
-        return await self.ch.fetchval(f"SELECT {field} FROM all_types WHERE uint8=1")
+        self._skip_unsupported(field)
+        return await self.engine_ch.fetchval(
+            f"SELECT {field} FROM all_types WHERE uint8=1"
+        )
 
     async def select_record(self, field):
-        return await self.ch.fetchrow(f"SELECT {field} FROM all_types WHERE uint8=1")
+        self._skip_unsupported(field)
+        return await self.engine_ch.fetchrow(
+            f"SELECT {field} FROM all_types WHERE uint8=1"
+        )
 
     async def select_field_bytes(self, field):
         return await self.ch.fetchval(

--- a/tests.py
+++ b/tests.py
@@ -298,21 +298,9 @@ class TestClient:
 @pytest.mark.types
 @pytest.mark.usefixtures("class_chclient", "class_engine")
 class TestTypes:
-    # Columns the Native engine cannot decode yet: LowCardinality uses a
-    # dictionary-encoded layout and Nested a columnar one (both phase 3), and
-    # the Native format ships DateTime64 without its timezone (returned as naive
-    # UTC, so it cannot match the tz-aware TSV/RowBinary value).
-    NATIVE_UNSUPPORTED = {
-        "low_cardinality_str",
-        "low_cardinality_nullable_str",
-        "low_cardinality_int",
-        "low_cardinality_date",
-        "low_cardinality_datetime",
-        "array_low_cardinality_string",
-        "nested_int",
-        "nested_str_date",
-        "datetime64",
-    }
+    # The Native format ships DateTime64 without its timezone, so a tz-aware
+    # column comes back as naive UTC and cannot match the tz-aware TSV value.
+    NATIVE_UNSUPPORTED = {"datetime64"}
 
     # The binary engines decode Float32 from its exact 4-byte IEEE-754 value,
     # whereas TSV ships ClickHouse's shorter text rounding (e.g. 23.432 vs
@@ -1647,7 +1635,8 @@ class TestNative:
     # The columnar Native read engine. Phase 1: numerics, String, FixedString,
     # Date, DateTime (UTC), Bool, Nullable, Array. Phase 2 adds the scalar
     # long-tail (Decimal, DateTime64, Enum, UUID, IPv4/6, Int128/256, ...) plus
-    # columnar Tuple and Map.
+    # columnar Tuple and Map. Phase 3 adds LowCardinality and Nested (covered by
+    # the cross-engine TestTypes matrix).
     NATIVE_DDL = """
         CREATE TABLE native_t (
             id UInt32, big Int64, neg Int16, score Float64, f32 Float32,
@@ -1743,10 +1732,10 @@ class TestNative:
 
     async def test_unsupported_type_raises(self):
         native = self._native_client()
-        # LowCardinality uses a dictionary-encoded columnar layout that the
-        # Native engine does not decode yet (Phase 3).
+        # Geo types (here Point) are not in the type mapping, so decoding must
+        # raise a clear error rather than silently misread the column.
         with pytest.raises(ChClientError):
-            await native.fetchval("SELECT toLowCardinality('x')")
+            await native.fetchval("SELECT (1.0, 2.0)::Point")
 
 
 class TestErrorBody:

--- a/tests.py
+++ b/tests.py
@@ -173,8 +173,7 @@ async def all_types_db(chclient, rows):
     await chclient.execute("DROP TABLE IF EXISTS test_cache")
     await chclient.execute("DROP TABLE IF EXISTS test_cache_mv")
     await chclient.execute("DROP TABLE IF EXISTS test_insert_file")
-    await chclient.execute(
-        """
+    await chclient.execute("""
     CREATE TABLE all_types (uint8 UInt8,
                             uint16 UInt16,
                             uint32 UInt32,
@@ -228,34 +227,27 @@ async def all_types_db(chclient, rows):
                             nested_int Nested(value1 Integer, value2 Integer),
                             nested_str_date Nested(value1 String, value2 Date)
                             ) ENGINE = Memory
-    """
-    )
-    await chclient.execute(
-        """
+    """)
+    await chclient.execute("""
         CREATE TABLE test_cache (
           key           String,
           int32Cache    AggregateFunction(avg, Int32),
           float32Cache  SimpleAggregateFunction(sum, Float64))
         ENGINE = AggregatingMergeTree()
         ORDER BY key
-        """
-    )
-    await chclient.execute(
-        """
+        """)
+    await chclient.execute("""
         CREATE MATERIALIZED VIEW test_cache_mv TO test_cache AS
           SELECT avgState(int32) AS int32Cache, sum(float32) AS float32Cache
           FROM all_types
-        """
-    )
-    await chclient.execute(
-        """
+        """)
+    await chclient.execute("""
         CREATE TABLE test_insert_file(
             uint32  UInt32,
             string  String,
             date    Date
         ) ENGINE = Memory
-        """
-    )
+        """)
     await chclient.execute("INSERT INTO all_types VALUES", *rows)
 
 
@@ -681,7 +673,7 @@ class TestTypes:
         record = await self.select_record_bytes("array_string")
         assert record[0] == result
         assert record["array_string"] == result
-    
+
     async def test_array_tuple(self):
         result = [("hello'", 3, "hello")]
         assert await self.select_field("array_tuple") == result
@@ -1428,7 +1420,11 @@ class TestRowBinaryDecode:
             UUID("1ea47c97-16a8-4338-877e-66f464374944"),
         ),
         ("IPv4", "8528fd74", IPv4Address("116.253.40.133")),
-        ("IPv6", "200144c8012926320033000002520002", IPv6Address("2001:44c8:129:2632:33:0:252:2")),
+        (
+            "IPv6",
+            "200144c8012926320033000002520002",
+            IPv6Address("2001:44c8:129:2632:33:0:252:2"),
+        ),
         ("Enum8('a' = 1, 'b' = 2)", "02", "b"),
         ("Nullable(UInt8)", "01", None),
         ("Nullable(UInt8)", "0005", 5),
@@ -1505,7 +1501,11 @@ class TestRowBinary:
         # widened to float64, so floats are compared with a tolerance.
         if isinstance(tsv_value, float):
             return bin_value == pytest.approx(tsv_value, rel=1e-6, abs=1e-6)
-        if isinstance(tsv_value, list) and tsv_value and isinstance(tsv_value[0], float):
+        if (
+            isinstance(tsv_value, list)
+            and tsv_value
+            and isinstance(tsv_value[0], float)
+        ):
             return all(
                 b == pytest.approx(t, rel=1e-6, abs=1e-6)
                 for t, b in zip(tsv_value, bin_value)
@@ -1536,8 +1536,7 @@ class TestRowBinary:
     async def test_insert_round_trip(self):
         binary = self._binary_client()
         await binary.execute("DROP TABLE IF EXISTS rb_insert")
-        await binary.execute(
-            """
+        await binary.execute("""
             CREATE TABLE rb_insert (
                 u8 UInt8, i64 Int64, f Float64, s String, fs FixedString(4),
                 d Date, dttm DateTime('UTC'),
@@ -1546,8 +1545,7 @@ class TestRowBinary:
                 e Enum8('a' = 1, 'b' = 2), arr Array(UInt8),
                 m Map(String, UInt8), nn Nullable(UInt8), tup Tuple(UInt8, String)
             ) ENGINE = Memory
-            """
-        )
+            """)
         row = (
             7,
             -5,
@@ -1592,8 +1590,10 @@ class TestRowBinary:
 @pytest.mark.usefixtures("class_chclient")
 class TestNative:
     # https://github.com/maximdanilchenko/aiochclient/issues/134
-    # The columnar Native read engine (Phase 1: numerics, String, FixedString,
-    # Date, DateTime (UTC), Bool, Nullable, Array).
+    # The columnar Native read engine. Phase 1: numerics, String, FixedString,
+    # Date, DateTime (UTC), Bool, Nullable, Array. Phase 2 adds the scalar
+    # long-tail (Decimal, DateTime64, Enum, UUID, IPv4/6, Int128/256, ...) plus
+    # columnar Tuple and Map.
     NATIVE_DDL = """
         CREATE TABLE native_t (
             id UInt32, big Int64, neg Int16, score Float64, f32 Float32,
@@ -1645,10 +1645,54 @@ class TestNative:
         rows = [r[0] async for r in native.iterate("SELECT number FROM numbers(3)")]
         assert rows == [0, 1, 2]
 
+    EXTENDED_DDL = """
+        CREATE TABLE native_ext (
+            id UInt32, dec Decimal(18, 4), ts64 DateTime64(3),
+            en Enum8('a' = 1, 'b' = 2), uid UUID, ip4 IPv4, ip6 IPv6,
+            big Int128, tup Tuple(UInt8, String), ntup Tuple(x UInt8, y String),
+            mp Map(String, UInt32), arr_tup Array(Tuple(UInt8, String)),
+            nl Nullable(Decimal(10, 2))
+        ) ENGINE = Memory
+        """
+
+    async def test_extended_types_match_tsv(self):
+        native = self._native_client()
+        await native.execute("DROP TABLE IF EXISTS native_ext")
+        await native.execute(self.EXTENDED_DDL)
+        rows = [
+            (
+                i,
+                Decimal("3.1416"),
+                dt.datetime(2021, 6, 1, 12, 30, 0, 123000),
+                "b",
+                UUID("12345678-1234-5678-1234-567812345678"),
+                IPv4Address("1.2.3.4"),
+                IPv6Address("::1"),
+                170141183460469231731687303715884105727,
+                (7, "hi"),
+                (9, "yo"),
+                {"k1": 10, "k2": 20},
+                [(1, "a"), (2, "b")],
+                (Decimal("5.50") if i % 2 else None),
+            )
+            for i in range(4)
+        ]
+        await native.execute("INSERT INTO native_ext VALUES", *rows)
+        tsv_rows = [
+            r[:] for r in await self.ch.fetch("SELECT * FROM native_ext ORDER BY id")
+        ]
+        nat_rows = [
+            r[:] for r in await native.fetch("SELECT * FROM native_ext ORDER BY id")
+        ]
+        assert tsv_rows == nat_rows
+        await native.execute("DROP TABLE IF EXISTS native_ext")
+
     async def test_unsupported_type_raises(self):
         native = self._native_client()
+        # LowCardinality uses a dictionary-encoded columnar layout that the
+        # Native engine does not decode yet (Phase 3).
         with pytest.raises(ChClientError):
-            await native.fetchval("SELECT 'b'::Enum8('a' = 1, 'b' = 2)")
+            await native.fetchval("SELECT toLowCardinality('x')")
 
 
 class TestErrorBody:

--- a/tests.py
+++ b/tests.py
@@ -1730,6 +1730,45 @@ class TestNative:
         assert tsv_rows == nat_rows
         await native.execute("DROP TABLE IF EXISTS native_ext")
 
+    async def test_insert_matches_tsv(self):
+        # Native INSERT (columnar write path) must store the same bytes as a
+        # plain TSV insert. Insert the identical rows both ways into twin tables
+        # and compare what comes back (read via TSV so the read engine is fixed).
+        native = self._native_client()
+        await native.execute("DROP TABLE IF EXISTS native_w")
+        await native.execute("DROP TABLE IF EXISTS native_w_ref")
+        await native.execute(self.EXTENDED_DDL.replace("native_ext", "native_w"))
+        await native.execute("CREATE TABLE native_w_ref AS native_w")
+        rows = [
+            (
+                i,
+                Decimal("12.3400"),
+                dt.datetime(2021, 6, 1, 12, 30, 0, 123000),
+                "a" if i % 2 else "b",
+                UUID("12345678-1234-5678-1234-567812345678"),
+                IPv4Address("9.8.7.6"),
+                IPv6Address("::2"),
+                -170141183460469231731687303715884105727,
+                (i % 256, "hi"),
+                (i % 256, "yo"),
+                {"k": i},
+                [(1, "a"), (2, "b")],
+                (Decimal("5.50") if i % 2 else None),
+            )
+            for i in range(6)
+        ]
+        await native.execute("INSERT INTO native_w VALUES", *rows)  # native write
+        await self.ch.execute("INSERT INTO native_w_ref VALUES", *rows)  # TSV write
+        written = [
+            r[:] for r in await self.ch.fetch("SELECT * FROM native_w ORDER BY id")
+        ]
+        reference = [
+            r[:] for r in await self.ch.fetch("SELECT * FROM native_w_ref ORDER BY id")
+        ]
+        assert written == reference
+        await native.execute("DROP TABLE IF EXISTS native_w")
+        await native.execute("DROP TABLE IF EXISTS native_w_ref")
+
     async def test_unsupported_type_raises(self):
         native = self._native_client()
         # Geo types (here Point) are not in the type mapping, so decoding must


### PR DESCRIPTION
  **Native columnar engine — `ChClient(session, native=True)`**
  - Decodes ClickHouse's column-oriented `Native` format: whole columns at once —
    fixed-width numerics through the stdlib `array` module, strings/dates in the
    compiled Cursor — then one transpose to rows. This is what lets an HTTP client
    rival the C/numpy clients on read throughput.
  - Full type coverage: numerics, Bool, String, FixedString, Date, DateTime,
    Decimal, DateTime64, Enum, UUID, IPv4/6, Int/UInt128/256, Nullable, Array,
    Tuple, Map, LowCardinality (incl. Nullable) and Nested. Unknown/geo types
    raise a clear `ChClientError`.
  - Columnar `INSERT`: rows are encoded column-by-column into one Native block
    (numeric columns straight from `array`), with LowCardinality/Nested sent in
    their simplified wire form (ClickHouse converts on insert).

  **RowBinary Cython acceleration — `ChClient(session, binary=True)`**
  - `cdef` Cursor, a C-level whole-row reader (no per-value Python dispatch) and an
    O(n) streaming reader. RowBinary now beats TSV in both directions.

  **Compiled `Record`**
    cheaply than the pure-Python `Mapping` subclass, which matters when a fetch
    wraps tens of thousands of rows. Speeds up *every* engine; the pure Record
    stays as the fallback with identical semantics.

  ## Performance (mixed-type rows, fully decoded, M1 Pro, CH 26.5, best-of-8)

  | aiochclient engine | SELECT | INSERT |
  |:--|--:|--:|
  | Native | ~730k rows/sec | ~330k rows/sec |
  | RowBinary | ~370k rows/sec | ~320k rows/sec |
  | TSV (default) | ~305k rows/sec | ~245k rows/sec |