### PR TITLE
Native engine: ~1M rows/sec SELECT by suppressing GC during materialization

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,54 @@
+name: Benchmarks
+
+# Manual-only: run from the Actions tab ("Run workflow"). GitHub-hosted runners
+# are modest shared VMs, so the absolute numbers are lower than a dev laptop —
+# but they are isolated and consistent, which makes them useful for tracking
+# relative changes / regressions between commits.
+on:
+  workflow_dispatch:
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r dev-requirements/dev-requirements-cython-ciso.txt
+          # the comparison clients are only needed for the benchmark
+          pip install clickhouse-connect clickhouse-driver asynch
+      - name: Build Cython extension
+        run: python setup.py build_ext --inplace
+      - name: Start ClickHouse (HTTP 8123 + native 9000)
+        run: |
+          docker run -p 8123:8123 -p 9000:9000 -d --name cs \
+            -e CLICKHOUSE_SKIP_USER_SETUP=1 clickhouse/clickhouse-server
+          for i in $(seq 1 30); do
+            curl -fs http://localhost:8123/ping | grep -q Ok && echo "ClickHouse is ready" && exit 0
+            sleep 1
+          done
+          echo "ClickHouse did not become ready" && exit 1
+      - name: Client comparison (benchmarks_vs_libs.py)
+        run: python benchmarks_vs_libs.py | tee bench_libs.txt
+      - name: Engine comparison (benchmarks.py)
+        run: python benchmarks.py | tee bench_formats.txt || true
+      - name: Publish results to the job summary
+        if: always()
+        run: |
+          {
+            echo '## Benchmark results'
+            echo '_GitHub-hosted runner (~4 vCPU); absolute numbers are lower than a dev machine but consistent._'
+            echo
+            echo '### Clients (`benchmarks_vs_libs.py`)'
+            echo '```'
+            cat bench_libs.txt 2>/dev/null || echo '(no output)'
+            echo '```'
+            echo '### Engines (`benchmarks.py`)'
+            echo '```'
+            cat bench_formats.txt 2>/dev/null || echo '(no output)'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/BENCHMARK_RESULTS.md
+++ b/BENCHMARK_RESULTS.md
@@ -30,32 +30,33 @@ real-world-ish workload. Reproduce with `benchmarks_vs_libs.py`.
 
 | Client | Protocol | Async | SELECT (decode) | INSERT |
 |:-------|:---------|:-----:|----------------:|-------:|
-| **aiochclient — Native** | HTTP | ✅ | **~730k** | ~330k |
+| **aiochclient — Native** | HTTP | ✅ | **~1,000k** | ~330k |
 | **aiochclient — RowBinary** | HTTP | ✅ | ~370k | ~320k |
 | **aiochclient — TSV** | HTTP | ✅ | ~305k | ~245k |
-| clickhouse-connect | HTTP | ✅ | **~820k** | **~450k** |
+| clickhouse-connect | HTTP | ✅ | ~820k | **~450k** |
 | asynch | native | ✅ | ~108k | ~165k |
 | clickhouse-driver | native | ❌ (sync) | ~440k | ~370k |
 
-Numbers are indicative (best-of-8; they vary ±10–20% run to run, INSERT more so)
-and depend on the data, the ClickHouse version and the machine.
+Numbers are indicative (best-of-8 on an otherwise-idle machine; they vary
+±10–20% run to run, INSERT more so) and depend on the data, the ClickHouse
+version and the machine. They are also sensitive to background CPU load — on a
+busy machine the absolute figures fall (the columnar decode is single-threaded),
+though the ordering holds.
 
 ## Takeaways
 
-- **aiochclient's Native engine** is the fastest async option on SELECT here and
-  is within reach of clickhouse-connect — while keeping aiochclient's small,
+- **aiochclient's Native engine is the fastest SELECT here** (~1M rows/sec),
+  ahead of clickhouse-connect, while keeping aiochclient's small,
   dependency-light footprint (**no numpy**). It decodes ClickHouse's columnar
-  `Native` format whole-column-at-once: fixed-width numerics straight through the
-  stdlib `array` module, strings/dates in the compiled Cursor, then one transpose
-  to rows.
-- **clickhouse-connect is still the fastest** on SELECT (and INSERT). It is the
-  official client and decodes the columnar binary format in C on top of numpy;
-  the residual SELECT gap to aiochclient-Native is essentially the cost of
-  wrapping each row in aiochclient's richer `Record` object — the raw
-  column-decode-and-transpose throughput is comparable.
+  `Native` format whole-column-at-once — fixed-width numerics straight through
+  the stdlib `array` module, strings/dates in the compiled Cursor, then one
+  transpose to rows — and, crucially, suppresses the cyclic garbage collector
+  while it allocates the result objects (see below).
+- **clickhouse-connect** is the official client and decodes the columnar binary
+  format in C on top of numpy; it is the next fastest on SELECT and the fastest
+  on INSERT.
 - **clickhouse-driver** (native protocol, C extensions) is fast but
   **synchronous** — not usable as-is in an asyncio app without a thread pool.
-  aiochclient-Native is faster than it on SELECT over plain HTTP.
 - **RowBinary** remains the best *row-oriented* engine (and the one used when
   streaming row-by-row via `iterate`); **TSV** is the zero-Cython baseline.
 - **asynch** is the slowest on SELECT here despite the native protocol — its
@@ -65,6 +66,10 @@ and depend on the data, the ClickHouse version and the machine.
 
 - The SELECT figures fully materialize every row (`row[:]`), so they measure
   decode + `Record` construction, not lazy passthrough.
+- The Native engine's big jump (from ~730k) came from **not running the cyclic
+  GC while a fetch allocates its tens of thousands of result objects** — none of
+  which are garbage. The collector is disabled only for the synchronous,
+  `await`-free decode/build sections and restored afterwards.
 - INSERT throughput is closer across clients: aiochclient-Native encodes numeric
   columns in bulk via `array`, but variable-width / mixed columns still encode
   per value, so its INSERT lands near RowBinary and clickhouse-driver rather than

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -13,3 +13,4 @@ global-exclude *.a
 global-exclude *.obj
 prune docs/_build
 prune dev-requirements
+prune perf_iterations

--- a/README.md
+++ b/README.md
@@ -187,27 +187,27 @@ apply the timezone).
 Engine comparison on mixed-type rows, fully decoded, with the Cython extension
 built:
 
-| Engine      | SELECT (decode) | INSERT         |
-|:------------|----------------:|---------------:|
-| `TSV`       | ~305k rows/sec  | ~245k rows/sec |
-| `RowBinary` | ~370k rows/sec  | ~320k rows/sec |
-| `Native`    | ~730k rows/sec  | ~330k rows/sec |
+| Engine      | SELECT (decode) | INSERT          |
+|:------------|----------------:|----------------:|
+| `TSV`       | ~305k rows/sec  | ~245k rows/sec  |
+| `RowBinary` | ~370k rows/sec  | ~320k rows/sec  |
+| `Native`    | ~1,000k rows/sec | ~330k rows/sec |
 
 Against the popular Python ClickHouse clients on the same workload, the Native
-engine is the fastest async SELECT option short of clickhouse-connect, and ahead
-of the synchronous clickhouse-driver:
+engine is the fastest SELECT, ahead of clickhouse-connect and of the synchronous
+clickhouse-driver:
 
-| Client                              | SELECT        | INSERT        |
-|:------------------------------------|--------------:|--------------:|
-| aiochclient — Native (HTTP, async)  | ~730k rows/sec | ~330k rows/sec |
-| clickhouse-connect (HTTP, async)    | ~820k rows/sec | ~450k rows/sec |
-| clickhouse-driver (native, sync)    | ~440k rows/sec | ~370k rows/sec |
-| asynch (native, async)              | ~108k rows/sec | ~165k rows/sec |
+| Client                              | SELECT          | INSERT         |
+|:------------------------------------|----------------:|---------------:|
+| aiochclient — Native (HTTP, async)  | ~1,000k rows/sec | ~330k rows/sec |
+| clickhouse-connect (HTTP, async)    | ~820k rows/sec   | ~450k rows/sec |
+| clickhouse-driver (native, sync)    | ~440k rows/sec   | ~370k rows/sec |
+| asynch (native, async)              | ~108k rows/sec   | ~165k rows/sec |
 
-Indicative best-of-8 figures (Apple M1 Pro, ClickHouse 26.5, single connection);
-they vary run to run and with the data. Full methodology lives in
-[BENCHMARK_RESULTS.md](BENCHMARK_RESULTS.md); reproduce with `benchmarks_vs_libs.py`
-(clients) and `benchmarks.py` (engines).
+Indicative best-of-8 figures on an otherwise-idle Apple M1 Pro (ClickHouse 26.5,
+single connection); they vary run to run, with the data, and with background CPU
+load. Full methodology lives in [BENCHMARK_RESULTS.md](BENCHMARK_RESULTS.md);
+reproduce with `benchmarks_vs_libs.py` (clients) and `benchmarks.py` (engines).
 
 ## Documentation
 

--- a/aiochclient/_types.pyx
+++ b/aiochclient/_types.pyx
@@ -1,5 +1,6 @@
 #cython: language_level=3
 import datetime as _dt
+import gc
 import json
 import re
 import struct
@@ -10,6 +11,9 @@ from uuid import UUID
 from zoneinfo import ZoneInfo
 
 from cpython cimport PyList_Append, PyUnicode_AsEncodedString, PyUnicode_Join
+from cpython.list cimport PyList_GET_ITEM, PyList_GET_SIZE
+from cpython.ref cimport Py_INCREF
+from cpython.tuple cimport PyTuple_New, PyTuple_SET_ITEM
 from cpython.datetime cimport (
     date,
     date_new,
@@ -1696,3 +1700,54 @@ cpdef Record record_new(tuple values, dict names):
     record._converters = None
     record._decoded = True
     return record
+
+
+cpdef list build_records(list columns, dict names):
+    """Transpose decoded ``columns`` into a list of :class:`Record` rows.
+
+    The Native engine decodes a block column-by-column; turning those parallel
+    lists into row records is the hottest step of a fetch. Doing the transpose
+    and the Record construction here — building each row tuple straight from the
+    column lists via the C API and filling the cdef class inline — avoids the
+    Python-level ``zip(*columns)``, the list comprehension and a per-row call.
+
+    Allocating tens of thousands of (GC-tracked) tuples and records in one go
+    otherwise keeps tripping the cyclic garbage collector mid-build, which is the
+    single biggest cost of a large fetch. None of these objects are garbage (they
+    are all about to be returned), so the collector is disabled for the duration
+    of the loop — this is a tight synchronous section with no ``await``, so no
+    other coroutine runs meanwhile — and its previous state is restored after.
+    """
+    cdef:
+        Py_ssize_t ncols = len(columns)
+        Py_ssize_t nrows, i, j
+        list out
+        tuple row
+        Record record
+        object column, item
+        bint gc_was_enabled
+    if ncols == 0:
+        return []
+    nrows = PyList_GET_SIZE(<object>PyList_GET_ITEM(columns, 0))
+    out = []
+    gc_was_enabled = gc.isenabled()
+    if gc_was_enabled:
+        gc.disable()
+    try:
+        for i in range(nrows):
+            row = PyTuple_New(ncols)
+            for j in range(ncols):
+                column = <object>PyList_GET_ITEM(columns, j)
+                item = <object>PyList_GET_ITEM(column, i)
+                Py_INCREF(item)
+                PyTuple_SET_ITEM(row, j, item)
+            record = Record.__new__(Record)
+            record._row = row
+            record._names = names
+            record._converters = None
+            record._decoded = True
+            out.append(record)
+    finally:
+        if gc_was_enabled:
+            gc.enable()
+    return out

--- a/aiochclient/native.py
+++ b/aiochclient/native.py
@@ -10,6 +10,7 @@ one, which is what lets this engine rival the columnar C clients without numpy.
 
 import array
 import datetime as dt
+import gc as _gc
 import re
 import sys
 from decimal import Decimal
@@ -31,6 +32,25 @@ try:
     from aiochclient._types import Cursor  # noqa: F401
 except ImportError:
     from aiochclient.types import Cursor  # noqa: F401
+
+# Compiled transpose+Record builder; pure-Python fallback below.
+try:
+    from aiochclient._types import build_records
+except ImportError:
+
+    def build_records(columns, names):
+        # Building all rows at once otherwise trips the cyclic GC mid-build; the
+        # objects are all about to be returned, so suppress it for this tight,
+        # await-free section and restore the collector afterwards.
+        gc_was_enabled = _gc.isenabled()
+        if gc_was_enabled:
+            _gc.disable()
+        try:
+            return [record_from_decoded(values, names) for values in zip(*columns)]
+        finally:
+            if gc_was_enabled:
+                _gc.enable()
+
 
 _LE = sys.byteorder == "little"
 
@@ -136,9 +156,23 @@ def _read_prefix(cursor, ctype):
 
 
 def decode_column_with_prefix(cursor, n, ctype):
-    """Read a whole top-level column: its state prefix, then its body."""
-    _read_prefix(cursor, ctype)
-    return decode_column(cursor, n, ctype)
+    """Read a whole top-level column: its state prefix, then its body.
+
+    Decoding a column allocates its whole value list (and, for strings/objects,
+    every element) at once; like the row build, that mass allocation otherwise
+    trips the cyclic GC mid-decode. This runs synchronously inside a single
+    ``reader.parse`` call (no ``await``), so the collector is disabled for it and
+    restored afterwards.
+    """
+    gc_was_enabled = _gc.isenabled()
+    if gc_was_enabled:
+        _gc.disable()
+    try:
+        _read_prefix(cursor, ctype)
+        return decode_column(cursor, n, ctype)
+    finally:
+        if gc_was_enabled:
+            _gc.enable()
 
 
 def decode_column(cursor, n, ctype):
@@ -270,7 +304,7 @@ async def blocks_from_native(
         if not num_rows:
             continue
         name_map = {name: index for index, name in enumerate(names)}
-        yield [record_from_decoded(values, name_map) for values in zip(*columns)]
+        yield build_records(columns, name_map)
 
 
 async def rows_from_native(

--- a/perf_iterations/bench_native.py
+++ b/perf_iterations/bench_native.py
@@ -1,0 +1,161 @@
+"""Focused Native-SELECT micro-benchmark + breakdown for the 1M rows/sec goal.
+
+Mirrors the SELECT workload of benchmarks_vs_libs.py (50k mixed-type rows, fully
+materialized) but isolates the Native engine and reports a breakdown so each
+optimization iteration can see *where* the time goes.
+
+Run:  python perf_iterations/bench_native.py [--profile]
+"""
+
+import asyncio
+import sys
+import time
+from datetime import date, datetime
+
+from aiohttp import ClientSession
+
+from aiochclient import ChClient
+from aiochclient.native import blocks_from_native, decode_column_with_prefix
+
+ROWS = 50_000
+RETRIES = 12
+
+DDL = """
+CREATE TABLE bench_native (
+    id UInt32, value Int64, score Float64, name String, created Date,
+    ts DateTime, tags Array(String), opt Nullable(Int32)
+) ENGINE = Memory
+"""
+_DATE = date(2021, 6, 1)
+_TS = datetime(2021, 6, 1, 12, 30, 0)
+ROWS_DATA = [
+    (
+        i,
+        i * 1000,
+        3.14159,
+        f"name_{i}",
+        _DATE,
+        _TS,
+        ["alpha", "beta", "gamma"],
+        (i if i % 2 else None),
+    )
+    for i in range(ROWS)
+]
+
+
+def speed(seconds):
+    return int(ROWS / seconds)
+
+
+async def best(fn):
+    await fn()
+    b = 1e9
+    for _ in range(RETRIES):
+        t = time.perf_counter()
+        await fn()
+        b = min(b, time.perf_counter() - t)
+    return b
+
+
+def _native_source(client, query):
+    return client._http_client.post_return_bytes(
+        url=client.url,
+        params={**client.params},
+        headers=client.headers,
+        data=(query + " FORMAT Native").encode(),
+    )
+
+
+async def main():
+    async with ClientSession() as session:
+        prep = ChClient(session)
+        await prep.execute("DROP TABLE IF EXISTS bench_native")
+        await prep.execute(DDL)
+        await prep.execute("INSERT INTO bench_native VALUES", *ROWS_DATA)
+        client = ChClient(session, native=True)
+
+        q = "SELECT * FROM bench_native"
+
+        async def headline():
+            rows = await client.fetch(q)
+            return [row[:] for row in rows]
+
+        async def fetch_only():
+            return await client.fetch(q)
+
+        async def blocks_count():
+            n = 0
+            async for blk in blocks_from_native(_native_source(client, q)):
+                n += len(blk)
+            return n
+
+        async def decode_only():
+            # decode every column to lists, no Record, no transpose
+            from aiochclient.binary import BinaryReader, read_binary_str
+
+            reader = BinaryReader(_native_source(client, q))
+            total = 0
+            while True:
+                try:
+                    nc = await reader.parse(lambda c: c.read_varint())
+                except Exception:
+                    break
+                nr = await reader.parse(lambda c: c.read_varint())
+                cols = []
+                for _ in range(nc):
+                    await reader.parse(read_binary_str)
+                    ct = (await reader.parse(read_binary_str)).decode()
+                    cols.append(
+                        await reader.parse(
+                            lambda c, ct=ct, nr=nr: decode_column_with_prefix(c, nr, ct)
+                        )
+                    )
+                total += nr
+            return total
+
+        print(f"Native SELECT breakdown: {ROWS} rows, best of {RETRIES}\n")
+        print(
+            f"  decode columns only      : {speed(await best(decode_only)):>9} rows/sec"
+        )
+        print(
+            f"  blocks -> Records (count) : {speed(await best(blocks_count)):>9} rows/sec"
+        )
+        print(
+            f"  fetch (build list)        : {speed(await best(fetch_only)):>9} rows/sec"
+        )
+        print(
+            f"  fetch + row[:] (HEADLINE) : {speed(await best(headline)):>9} rows/sec"
+        )
+
+        await prep.execute("DROP TABLE IF EXISTS bench_native")
+
+
+def profile():
+    import cProfile
+    import pstats
+
+    async def run():
+        async with ClientSession() as session:
+            prep = ChClient(session)
+            await prep.execute("DROP TABLE IF EXISTS bench_native")
+            await prep.execute(DDL)
+            await prep.execute("INSERT INTO bench_native VALUES", *ROWS_DATA)
+            client = ChClient(session, native=True)
+            for _ in range(20):
+                rows = await client.fetch("SELECT * FROM bench_native")
+                [row[:] for row in rows]
+            await prep.execute("DROP TABLE IF EXISTS bench_native")
+
+    pr = cProfile.Profile()
+    pr.enable()
+    asyncio.run(run())
+    pr.disable()
+    stats = pstats.Stats(pr).sort_stats("tottime")
+    stats.print_stats(25)
+
+
+if __name__ == "__main__":
+    if "--profile" in sys.argv:
+        profile()
+    else:
+        asyncio.run(main())

--- a/perf_iterations/iter_00_baseline.md
+++ b/perf_iterations/iter_00_baseline.md
@@ -1,0 +1,38 @@
+# Iteration 0 — baseline + profile
+
+Goal: Native SELECT 730k → **1,000k rows/sec** (50k mixed rows, best-of-12, M1 Pro, CH 26.5).
+
+## Breakdown (`bench_native.py`)
+
+| stage | rows/sec |
+|---|---|
+| decode columns only | **1,289k** |
+| blocks → Records (count) | 780k |
+| fetch (build list) | 790k |
+| **fetch + row[:] (HEADLINE)** | **747k** |
+
+## Profile (`--profile`, 20 fetches, tottime)
+
+| tottime | what |
+|---|---|
+| 0.753s | `native.py:273 <listcomp>` — `[record_from_decoded(v, nm) for v in zip(*columns)]` |
+| 0.636s | kqueue control (HTTP IO wait, not CPU) |
+| 0.476s | `decode_column` |
+| 0.146s | `_execute` |
+| 0.048s | Nullable listcomp (`native.py:173`) |
+| 0.034s | `array.tolist()` |
+
+## Read
+
+The headline ceiling is the columnar decode at ~1.29M. The row-build step
+(transpose `zip(*columns)` + per-row `Record` construction) is the single
+biggest CPU cost — **larger than the decode itself**. That is the gap between
+1.29M and 747k.
+
+## Next (iteration 1)
+
+Move the transpose + Record construction into a single Cython function
+`build_records(columns, name_map)` that builds each row tuple from the column
+lists and constructs the `cdef class Record` inline (no Python `zip`, no list
+comprehension, no per-row cpdef dispatch). Pure-Python fallback keeps the
+current comprehension.

--- a/perf_iterations/iter_01_build_records.md
+++ b/perf_iterations/iter_01_build_records.md
@@ -1,0 +1,21 @@
+# Iteration 1 — Cython `build_records` (transpose + Record in C)
+
+Replaced the Python `[record_from_decoded(v, nm) for v in zip(*columns)]` in
+`blocks_from_native` with a Cython `build_records(columns, name_map)` that builds
+each row tuple from the column lists via the C API and fills the cdef Record
+inline (no `zip`, no comprehension, no per-row cpdef call).
+
+## Result
+
+| stage | baseline | iter 1 |
+|---|---|---|
+| fetch + row[:] (HEADLINE) | 747k | **776k** (~+4%) |
+| blocks → Records (count) | 780k | 781k |
+
+## Read
+
+Barely moved. In isolation `build_records` does **4.3M rows/sec** and a plain
+`list(zip(*cols))` does **9.9M** — so the row-build loop was never the
+bottleneck. The cost is elsewhere: allocating ~100k GC-tracked objects (50k
+tuples + 50k records) per fetch. Kept the change (it's strictly cheaper and sets
+up iter 2) and pivoted to the real cause.

--- a/perf_iterations/iter_02_gc_in_build.md
+++ b/perf_iterations/iter_02_gc_in_build.md
@@ -1,0 +1,35 @@
+# Iteration 2 — suppress cyclic GC during `build_records` ⭐
+
+## Diagnosis
+
+Disabling the cyclic garbage collector globally for the whole fetch took the
+headline from ~693k to **1,239,762 rows/sec** in a controlled test. Cause:
+materializing ~100k GC-tracked containers (50k row tuples + 50k records) per
+fetch repeatedly trips generational GC mid-build, even though none of those
+objects are garbage (they are all about to be returned).
+
+## Change
+
+`build_records` (Cython + pure fallback) now disables GC for its loop and
+restores the previous state afterwards. This is a tight, synchronous,
+`await`-free section, so no other coroutine runs while GC is off — it is safe
+and contained (GC still runs normally between blocks / during IO).
+
+## Result
+
+| stage | baseline | iter 2 |
+|---|---|---|
+| decode columns only | 1289k | ~1180k |
+| blocks → Records (count) | 780k | **998k** |
+| fetch (build list) | 790k | **1010k** |
+| **fetch + row[:] (HEADLINE)** | 747k | **~1011k** |
+
+Official `benchmarks_vs_libs.py`: aiochclient Native SELECT **910k** — now ahead
+of clickhouse-connect (~831k) on the same workload.
+
+## Read
+
+Goal essentially reached (hovering 0.91M–1.01M across runs, ±5–10% variance).
+The residual gap to the global-GC-off ceiling (~1.24M) is GC during the *decode*
+phase (column-list allocation). Iter 3 will suppress that too — only in the
+synchronous decode section, to stay safe.

--- a/perf_iterations/iter_03_gc_in_decode.md
+++ b/perf_iterations/iter_03_gc_in_decode.md
@@ -1,0 +1,53 @@
+# Iteration 3 — suppress GC during column decode too ✅ GOAL MET
+
+## Change
+
+Extended the iter-2 idea to the decode side: `decode_column_with_prefix`
+(per-column, called once inside each synchronous `reader.parse`) now disables
+the cyclic GC around the prefix read + column body decode, restoring it after.
+Like `build_records`, this is an `await`-free synchronous section, so it is safe
+and contained; GC still runs between columns/blocks and during HTTP IO.
+
+Decoding allocates each column's whole value list (and every string/object
+element) at once — the same mass-allocation that trips generational GC.
+
+## Result (`bench_native.py`, best of 12)
+
+| stage | baseline | iter 2 | iter 3 |
+|---|---|---|---|
+| decode columns only | 1289k | ~1180k | **1326k** |
+| blocks → Records (count) | 780k | 998k | **1098k** |
+| fetch (build list) | 790k | 1010k | **1074k** |
+| **fetch + row[:] (HEADLINE)** | 747k | ~1011k | **~1040k** (1049 / 1039 / 1039) |
+
+## Official `benchmarks_vs_libs.py`
+
+```
+aiochclient (HTTP, Native)    select 1000175 rows/sec | insert  411763 rows/sec
+clickhouse-connect (HTTP)     select  785671 rows/sec | insert  365199 rows/sec
+clickhouse-driver (native)    select  449009 rows/sec | insert  408229 rows/sec
+```
+
+**Native SELECT ≥ 1,000,000 rows/sec — goal reached**, and now the fastest
+client in the comparison (ahead of clickhouse-connect), still numpy-free.
+
+## Correctness
+
+Full suite 909 passed on cython, pure-Python fallback green. GC state is
+captured/restored with try/finally on every path (including the NeedMoreData
+retry), and every disabled region is synchronous (no `await`), so no other
+coroutine ever runs with GC off.
+
+## Summary of what moved the needle
+
+The whole 730k → 1.0M gain came from **not letting the cyclic garbage collector
+run while a fetch allocates its tens of thousands of result objects** — none of
+which are garbage. The Cython transpose (iter 1) was a near-no-op on its own;
+the row-build loop was never the bottleneck.
+
+## Possible follow-ups (not done here)
+
+- The same GC-suppression could help the RowBinary row driver, but it builds
+  rows one-by-one across `await` points, so it would need per-row toggling
+  (overhead) or an unsafe await-spanning disable — needs care.
+- Update README / BENCHMARK_RESULTS.md headline numbers if this lands.

--- a/perf_iterations/iter_04_load_sensitivity_and_safety.md
+++ b/perf_iterations/iter_04_load_sensitivity_and_safety.md
@@ -1,0 +1,52 @@
+# Iteration 4 — load sensitivity, GC-safety tests, docs
+
+Wrap-up after reaching the 1M goal in iter 3. Two things: confirm the win is
+real (not a measurement fluke) and lock it down with safety tests + docs.
+
+## Measurement is load-sensitive (be honest about it)
+
+Re-running later, the absolute numbers had collapsed: focused headline ~350–390k,
+`decode columns only` ~460k (vs ~1.33M earlier) — and clickhouse-connect was
+*also* not at its earlier peak. Cause: background CPU load on this (corporate)
+laptop — `jamf protect` security scanning (~23% CPU) and the Dockerised
+ClickHouse under qemu (~29%), load average ~3–4. The single-threaded columnar
+decode gets squeezed (likely onto efficiency cores), so the absolute throughput
+roughly tracks how busy the machine is.
+
+Controlled A/B in one process (so load is identical for both arms):
+
+| machine state | gc-naive (pre-opt) | gc-managed (this change) | gc fully disabled |
+|---|---|---|---|
+| idle (earlier) | ~693k | ~1,040k | ~1,240k |
+| loaded (now) | ~322k | ~379k | ~384k |
+
+Two facts hold regardless of load:
+1. **The optimization always helps and never hurts** — gc-managed beats gc-naive
+   (1.15× under heavy load, ~1.8× idle) and **matches the gc-fully-disabled
+   ceiling**, i.e. it captures essentially all of the available GC win safely.
+2. The headline of ~1.0M rows/sec is real on an otherwise-idle machine
+   (reproduced across several focused runs at ~1.04M and the official
+   `benchmarks_vs_libs.py` at 1,000,175).
+
+Docs (README, BENCHMARK_RESULTS.md) quote the idle-machine figures with an
+explicit "sensitive to background load" caveat.
+
+## GC-safety tests (added to `TestNative`)
+
+The optimization disables the cyclic collector in synchronous sections, so the
+risk is mismanaging that global flag. Three tests pin the contract:
+
+- `test_fetch_restores_gc_state` — GC enabled before a fetch ⇒ enabled after.
+- `test_fetch_preserves_caller_gc_disabled` — if the caller disabled GC, a fetch
+  must **not** turn it back on (we only re-enable what we disabled).
+- `test_gc_state_restored_after_decode_error` — an error raised mid-decode still
+  restores the flag (the `try/finally` covers every path, incl. the retry).
+
+All green (12 = 3 × http×config). Full suite 912 passed on cython, pure fallback
+green.
+
+## Status
+
+Optimization shipped as-is. The riskier "disable GC across the whole fetch
+(spanning awaits)" path — which reached ~1.24M idle — was deliberately **not**
+taken: it would leave GC off across `await` points, a footgun under concurrency.

--- a/tests.py
+++ b/tests.py
@@ -1,4 +1,5 @@
 import datetime as dt
+import gc
 import json
 import os
 from decimal import Decimal
@@ -1775,6 +1776,46 @@ class TestNative:
         # raise a clear error rather than silently misread the column.
         with pytest.raises(ChClientError):
             await native.fetchval("SELECT (1.0, 2.0)::Point")
+
+    # -- GC-suppression safety (the Native materialization disables the cyclic
+    # collector for its synchronous build/decode sections) --
+
+    async def test_fetch_restores_gc_state(self):
+        native = self._native_client()
+        was_enabled = gc.isenabled()
+        gc.enable()
+        try:
+            await native.fetch("SELECT number FROM numbers(5000)")
+            assert gc.isenabled(), "fetch must leave the collector enabled"
+        finally:
+            if not was_enabled:
+                gc.disable()
+
+    async def test_fetch_preserves_caller_gc_disabled(self):
+        # If the caller already turned GC off, a fetch must not turn it back on.
+        native = self._native_client()
+        was_enabled = gc.isenabled()
+        gc.disable()
+        try:
+            await native.fetch("SELECT number FROM numbers(5000)")
+            assert not gc.isenabled(), "fetch must not re-enable a caller-disabled GC"
+        finally:
+            if was_enabled:
+                gc.enable()
+
+    async def test_gc_state_restored_after_decode_error(self):
+        # An error raised mid-decode must still restore the collector (the
+        # disable/enable is guarded by try/finally on every path).
+        native = self._native_client()
+        was_enabled = gc.isenabled()
+        gc.enable()
+        try:
+            with pytest.raises(ChClientError):
+                await native.fetchval("SELECT (1.0, 2.0)::Point")
+            assert gc.isenabled()
+        finally:
+            if not was_enabled:
+                gc.disable()
 
 
 class TestErrorBody:


### PR DESCRIPTION
A focused performance pass on the Native read engine: SELECT throughput goes from ~730k to ~1,000k rows/sec on the mixed-type benchmark (50k rows, idle M1 Pro, CH 26.5), making it the fastest client in the comparison, ahead of clickhouse-connect, while staying numpy-free.

The real cost was the **cyclic garbage collector**: a fetch allocates ~100k GC-tracked containers (one tuple + one Record per row), which repeatedly trips generational GC mid-fetch - even though none of those objects are garbage, they are all about to be returned. A controlled `gc.disable()` test jumped the headline from ~693k to ~1.24M, confirming it.

The riskier "disable GC across the whole fetch (spanning `await`s)" variant - which reached ~1.24M - was deliberately **not** taken; it would be a footgun under concurrency.

No public API change; behavior is identical, just faster.