### PR TITLE
Support ClickHouse geo types (Point, Ring, LineString, MultiLineString, Polygon, MultiPolygon)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Performance (Native engine):
 
 New:
 - `insert_block_size` (default 8192) controls the Native-INSERT block size.
+- Geo types (`Point`, `Ring`, `LineString`, `MultiLineString`, `Polygon`,
+  `MultiPolygon`) on all three engines
+  ([#136](https://github.com/maximdanilchenko/aiochclient/issues/136)).
 
 Note:
 - A multi-block native INSERT is **not atomic** on a client-side *encoding*

--- a/README.md
+++ b/README.md
@@ -274,6 +274,12 @@ vice-versa.
 | `LowCardinality(T)`  | `T`                     |
 | `Map(T1, T2)`        | `Dict[T1, T2]`          |
 | `Nested(T1, T2, ...)` | `List[Tuple[T1, T2, ...], Tuple[T1, T2, ...]]` |
+| `Point`              | `Tuple[float, float]`   |
+| `Ring`               | `List[Tuple[float, float]]` |
+| `LineString`         | `List[Tuple[float, float]]` |
+| `MultiLineString`    | `List[List[Tuple[float, float]]]` |
+| `Polygon`            | `List[List[Tuple[float, float]]]` |
+| `MultiPolygon`       | `List[List[List[Tuple[float, float]]]]` |
 
 
 ## Connection Pool Settings

--- a/aiochclient/_types.pyx
+++ b/aiochclient/_types.pyx
@@ -981,11 +981,16 @@ cdef class DateTime64Type(_RBType):
 cdef class TupleType(_RBType):
 
     cdef:
-        str name
+        # readonly: the geo subclasses normalise ``name`` to the composite they
+        # are, and GEO_WIRE_TYPES reads it back for the columnar engine.
+        readonly str name
         bint container
         tuple types
 
-    def __cinit__(self, str name, bint container):
+    # The name is parsed in __init__ (not __cinit__) so that a subclass can pass
+    # its own name down: Cython runs a base __cinit__ before the subclass and
+    # with the original arguments. See PointType below.
+    def __init__(self, str name, bint container):
         self.name = name
         self.container = container
         cdef str tps = RE_TUPLE.findall(name)[0]
@@ -1081,11 +1086,12 @@ cdef class MapType(_RBType):
 cdef class ArrayType(_RBType):
 
     cdef:
-        str name
+        readonly str name
         bint container
         type
 
-    def __cinit__(self, str name, bint container):
+    # Parsed in __init__ for the geo subclasses; see TupleType above.
+    def __init__(self, str name, bint container):
         self.name = name
         self.container = container
         self.type = what_py_type(
@@ -1118,6 +1124,50 @@ cdef class ArrayType(_RBType):
 
     cpdef list convert(self, bytes value):
         return self.p_type(value.decode())
+
+
+# ClickHouse geo types are named composites (see types.py): each class inherits
+# the Tuple/Array it is and passes that composite's name to the base.
+cdef class PointType(TupleType):
+    """``Point`` is ``Tuple(Float64, Float64)``."""
+
+    def __init__(self, str name, bint container=False):
+        TupleType.__init__(self, "Tuple(Float64, Float64)", container)
+
+
+cdef class RingType(ArrayType):
+    """``Ring`` is ``Array(Point)``."""
+
+    def __init__(self, str name, bint container=False):
+        ArrayType.__init__(self, "Array(Point)", container)
+
+
+cdef class LineStringType(ArrayType):
+    """``LineString`` is ``Array(Point)``."""
+
+    def __init__(self, str name, bint container=False):
+        ArrayType.__init__(self, "Array(Point)", container)
+
+
+cdef class MultiLineStringType(ArrayType):
+    """``MultiLineString`` is ``Array(LineString)``."""
+
+    def __init__(self, str name, bint container=False):
+        ArrayType.__init__(self, "Array(LineString)", container)
+
+
+cdef class PolygonType(ArrayType):
+    """``Polygon`` is ``Array(Ring)``."""
+
+    def __init__(self, str name, bint container=False):
+        ArrayType.__init__(self, "Array(Ring)", container)
+
+
+cdef class MultiPolygonType(ArrayType):
+    """``MultiPolygon`` is ``Array(Polygon)``."""
+
+    def __init__(self, str name, bint container=False):
+        ArrayType.__init__(self, "Array(Polygon)", container)
 
 
 cdef class NestedType(_RBType):
@@ -1451,6 +1501,12 @@ cdef dict CH_TYPES_MAPPING = {
     "IPv4": IPv4Type,
     "IPv6": IPv6Type,
     "Nested": NestedType,
+    "Point": PointType,
+    "Ring": RingType,
+    "LineString": LineStringType,
+    "MultiLineString": MultiLineStringType,
+    "Polygon": PolygonType,
+    "MultiPolygon": MultiPolygonType,
 }
 
 
@@ -1470,6 +1526,26 @@ cpdef what_py_type(str name, bint container = False):
 cpdef what_py_converter(str name, bint container = False):
     """ Returns needed type class from clickhouse type name """
     return what_py_type(name, container).convert
+
+
+cdef tuple _GEO_CLASSES = (
+    PointType,
+    RingType,
+    LineStringType,
+    MultiLineStringType,
+    PolygonType,
+    MultiPolygonType,
+)
+
+# Geo type name -> the composite it is stored as, derived from the classes
+# themselves. Python-visible (unlike the cdef CH_TYPES_MAPPING) because native.py
+# imports it: the columnar engine dispatches on the type string, not on a type
+# object.
+GEO_WIRE_TYPES = {
+    name: ch_type(name).name
+    for name, ch_type in CH_TYPES_MAPPING.items()
+    if issubclass(ch_type, _GEO_CLASSES)
+}
 
 
 cdef bytes unconvert_str(object value):

--- a/aiochclient/native.py
+++ b/aiochclient/native.py
@@ -33,6 +33,13 @@ try:
 except ImportError:
     from aiochclient.types import Cursor  # noqa: F401
 
+# Geo type name -> the composite it is stored as (derived from the geo type
+# classes); this engine dispatches on the type string, not on a type object.
+try:
+    from aiochclient._types import GEO_WIRE_TYPES
+except ImportError:
+    from aiochclient.types import GEO_WIRE_TYPES
+
 # Compiled String-column encoder; pure-Python fallback below.
 try:
     from aiochclient._types import write_string_column
@@ -279,6 +286,11 @@ def decode_column(cursor, n, ctype):
         # Array(Tuple(...)) of its sub-fields (shared offsets, then each field
         # as a flat sub-column), so decode it as such.
         return decode_column(cursor, n, "Array(Tuple(" + ctype[7:-1] + "))")
+    geo = GEO_WIRE_TYPES.get(ctype)
+    if geo is not None:
+        # A geo column is its composite on the wire, and a composite column is
+        # laid out as sub-columns, not as per-value RowBinary.
+        return decode_column(cursor, n, geo)
     # Generic per-value fallback through the compiled RowBinary readers — covers
     # Decimal, DateTime64, Enum, UUID, IPv4/6, Int128/256 and any other
     # fixed-layout scalar whose Native column is its RowBinary values back to back.
@@ -387,7 +399,10 @@ def _wire_type(ctype):
             + ", ".join(_wire_element(s) for s in _split_args(ctype[6:-1]))
             + ")"
         )
-    return ctype
+    # A geo column is sent as its composite; the server converts the block back
+    # to the column's declared type. Recurse: the composite may be Array(Point).
+    geo = GEO_WIRE_TYPES.get(ctype)
+    return _wire_type(geo) if geo is not None else ctype
 
 
 def _wire_element(spec):

--- a/aiochclient/types.py
+++ b/aiochclient/types.py
@@ -733,6 +733,63 @@ class ArrayType(BaseType):
         return b"[" + b",".join(py2ch(elem) for elem in value) + b"]"
 
 
+# ClickHouse geo types are named composites: each one *is* the Tuple/Array
+# below, on every wire format, so each class inherits that composite's codec and
+# just hands its own composite name to the base constructor.
+class PointType(TupleType):
+    """``Point`` is ``Tuple(Float64, Float64)``."""
+
+    __slots__ = ()
+
+    def __init__(self, name: str, **kwargs):
+        super().__init__("Tuple(Float64, Float64)", **kwargs)
+
+
+class RingType(ArrayType):
+    """``Ring`` is ``Array(Point)``."""
+
+    __slots__ = ()
+
+    def __init__(self, name: str, **kwargs):
+        super().__init__("Array(Point)", **kwargs)
+
+
+class LineStringType(ArrayType):
+    """``LineString`` is ``Array(Point)``."""
+
+    __slots__ = ()
+
+    def __init__(self, name: str, **kwargs):
+        super().__init__("Array(Point)", **kwargs)
+
+
+class MultiLineStringType(ArrayType):
+    """``MultiLineString`` is ``Array(LineString)``."""
+
+    __slots__ = ()
+
+    def __init__(self, name: str, **kwargs):
+        super().__init__("Array(LineString)", **kwargs)
+
+
+class PolygonType(ArrayType):
+    """``Polygon`` is ``Array(Ring)``."""
+
+    __slots__ = ()
+
+    def __init__(self, name: str, **kwargs):
+        super().__init__("Array(Ring)", **kwargs)
+
+
+class MultiPolygonType(ArrayType):
+    """``MultiPolygon`` is ``Array(Polygon)``."""
+
+    __slots__ = ()
+
+    def __init__(self, name: str, **kwargs):
+        super().__init__("Array(Polygon)", **kwargs)
+
+
 class NestedType(BaseType):
     __slots__ = ("name", "types")
 
@@ -931,6 +988,12 @@ CH_TYPES_MAPPING = {
     "IPv4": IPv4Type,
     "IPv6": IPv6Type,
     "Nested": NestedType,
+    "Point": PointType,
+    "Ring": RingType,
+    "LineString": LineStringType,
+    "MultiLineString": MultiLineStringType,
+    "Polygon": PolygonType,
+    "MultiPolygon": MultiPolygonType,
 }
 
 PY_TYPES_MAPPING = {
@@ -969,6 +1032,27 @@ def what_py_type(name: str, container: bool = False) -> BaseType:
 def what_py_converter(name: str, container: bool = False) -> Callable:
     """Returns needed type class from clickhouse type name"""
     return what_py_type(name, container).convert
+
+
+_GEO_CLASSES = (
+    PointType,
+    RingType,
+    LineStringType,
+    MultiLineStringType,
+    PolygonType,
+    MultiPolygonType,
+)
+
+# Geo type name -> the composite it is stored as, derived from the classes
+# themselves (each one normalises its ``name`` to that composite). The columnar
+# engine dispatches on the type *string* rather than on a type object — a Native
+# Array/Tuple column is offsets plus sub-columns, not per-value RowBinary — so it
+# needs the name; see ``native.decode_column``.
+GEO_WIRE_TYPES = {
+    name: ch_type(name).name
+    for name, ch_type in CH_TYPES_MAPPING.items()
+    if issubclass(ch_type, _GEO_CLASSES)
+}
 
 
 def read_column(cursor, reader, n: int) -> list:

--- a/tests.py
+++ b/tests.py
@@ -1168,10 +1168,17 @@ class TestFetching:
         # https://github.com/maximdanilchenko/aiochclient/issues/98
         rows = await self.ch.fetch("EXPLAIN SELECT 1")
         assert rows
-        assert all(isinstance(row[0], str) for row in rows)
+        # ClickHouse 26.7 made the `pretty` plan format the default, and it puts
+        # a blank line between the output columns and the plan tree. A blank TSV
+        # line decodes to an empty Record (that is what the `WITH TOTALS`
+        # separator looks like), so only the non-empty rows carry plan text.
+        assert any(len(row) for row in rows)
+        assert all(isinstance(row[0], str) for row in rows if len(row))
 
         value = await self.ch.fetchval("EXPLAIN SYNTAX SELECT 1 + 1")
-        assert value == "SELECT 1 + 1"
+        # ClickHouse 26.7 prints operators as function calls; older servers
+        # printed the operator form.
+        assert value in ("SELECT plus(1, 1)", "SELECT 1 + 1")
 
     async def test_quoted_string(self):
         record = await self.ch.fetchrow("SELECT 'foo\\'bar' AS quoted_string")

--- a/tests.py
+++ b/tests.py
@@ -1013,6 +1013,33 @@ class TestTypes:
         assert await self.ch.fetchval("SELECT a FROM t_issue_123") == value
         await self.ch.execute("DROP TABLE IF EXISTS t_issue_123")
 
+    async def test_geo_types(self):
+        # https://github.com/maximdanilchenko/aiochclient/issues/136
+        # Exactly representable floats, so equality holds on every engine.
+        point = (3.0, 4.0)
+        ring = [(0.0, 0.0), (10.0, 0.0), (10.0, 10.0), (0.0, 10.0)]
+        line = [(0.0, 0.0), (1.0, 1.0), (2.0, 4.0)]
+        multi_line = [line, [(5.0, 5.0), (6.0, 6.0)]]
+        polygon = [ring, [(4.0, 4.0), (5.0, 4.0), (5.0, 5.0)]]
+        multi_polygon = [polygon, [[(-1.0, -1.0), (-2.0, -1.0), (-2.0, -2.0)]]]
+        await self.ch.execute("DROP TABLE IF EXISTS t_geo")
+        await self.ch.execute(
+            "CREATE TABLE t_geo (p Point, r Ring, ls LineString, "
+            "mls MultiLineString, pg Polygon, mpg MultiPolygon) ENGINE = Memory"
+        )
+        await self.engine_ch.execute(
+            "INSERT INTO t_geo VALUES",
+            (point, ring, line, multi_line, polygon, multi_polygon),
+        )
+        record = await self.engine_ch.fetchrow("SELECT * FROM t_geo")
+        assert record["p"] == point
+        assert record["r"] == ring
+        assert record["ls"] == line
+        assert record["mls"] == multi_line
+        assert record["pg"] == polygon
+        assert record["mpg"] == multi_polygon
+        await self.ch.execute("DROP TABLE IF EXISTS t_geo")
+
     async def test_map_with_multiple_entries(self):
         # https://github.com/maximdanilchenko/aiochclient/issues/118
         value = {"a": 1, "b": 2, "c": 3}
@@ -1813,10 +1840,10 @@ class TestNative:
 
     async def test_unsupported_type_raises(self):
         native = self._native_client()
-        # Geo types (here Point) are not in the type mapping, so decoding must
-        # raise a clear error rather than silently misread the column.
+        # Interval types are not in the type mapping, so decoding must raise a
+        # clear error rather than silently misread the column.
         with pytest.raises(ChClientError):
-            await native.fetchval("SELECT (1.0, 2.0)::Point")
+            await native.fetchval("SELECT INTERVAL 1 DAY")
 
     # -- GC-suppression safety (the Native materialization disables the cyclic
     # collector for its synchronous build/decode sections) --
@@ -1852,7 +1879,7 @@ class TestNative:
         gc.enable()
         try:
             with pytest.raises(ChClientError):
-                await native.fetchval("SELECT (1.0, 2.0)::Point")
+                await native.fetchval("SELECT INTERVAL 1 DAY")
             assert gc.isenabled()
         finally:
             if not was_enabled:


### PR DESCRIPTION
> **Note on the first commit.** This branch also carries the test fix from #145 (`test_explain_with_fetch` breaks on ClickHouse 26.7 for everyone, including master, because the CI image is not pinned). Without it CI here is red for a reason that has nothing to do with geo. Once #145 is merged I will rebase and that commit will disappear from this PR — review it there, not here.

Adds the geo types requested in #136. The other types from that issue (JSON/Object, Variant, Dynamic) are untouched here — they need their own serialization work, so I kept this PR to geo.

### What's inside

Geo types are named composites: `Point` is `Tuple(Float64, Float64)`, `Ring` and `LineString` are `Array(Point)`, `Polygon` is `Array(Ring)`, `MultiPolygon` is `Array(Polygon)`, and ClickHouse serializes them exactly that way on every format. So there are no new codecs here — each geo type is a type class that inherits the composite it is stored as and hands that composite's name to the base:

```python
class PointType(TupleType):
    """``Point`` is ``Tuple(Float64, Float64)``."""

    __slots__ = ()

    def __init__(self, name: str, **kwargs):
        super().__init__("Tuple(Float64, Float64)", **kwargs)
```

They are registered in `CH_TYPES_MAPPING` like every other type, so TSV and RowBinary work through the existing machinery in both directions, nesting included (`Array(Point)`, `Nullable(Point)`, `Map(String, Polygon)`). `what_py_type` itself is unchanged.

The Native engine dispatches on the type string rather than on a type object — a columnar `Array`/`Tuple` is offsets plus sub-columns, not per-value RowBinary — so it resolves the composite through `GEO_WIRE_TYPES`, a table derived from the geo classes themselves rather than maintained by hand. Both lookups sit where the existing checks have already missed, so nothing extra runs for anyone who doesn't use geo columns.

The Python → ClickHouse direction needed nothing: a point is a `tuple`, a ring is a `list`.

### One structural change worth your attention

In `_types.pyx`, `TupleType` and `ArrayType` now parse their name in `__init__` instead of `__cinit__`. Cython runs a base `__cinit__` before the subclass and with the original arguments, so otherwise a geo subclass has no way to pass its composite name down (it blows up on `RE_TUPLE.findall("Point")[0]`). The bodies are unchanged, and the whole Tuple/Array/Map/Nested suite covers the change. Type objects are built once per column per query, so `__cinit__` vs `__init__` makes no measurable difference — benchmarks before/after are within noise.

`TupleType.name` and `ArrayType.name` became `readonly` so `GEO_WIRE_TYPES` can read the composite back out of the classes.

### Tests

New `test_geo_types` in `TestTypes`, which is already parametrized over all three engines and both inserts and reads through the engine under test.

`TestNative.test_unsupported_type_raises` and `test_gc_state_restored_after_decode_error` used `Point` as their "not in the type mapping" example; they now use `INTERVAL 1 DAY`.

I also ran, outside the suite: all nine insert-engine × read-engine combinations; nested geo (`Array(Point)`, `Tuple(String, Polygon)`, `Map(String, Ring)`, and `Nullable(Point)` with `enable_nullable_tuple_type=1`); empty rings and polygons; a polygon with a hole; negative and fractional coordinates. Full suite passes in both builds (pure Python and with the Cython extension).

`LineString`/`MultiLineString` require ClickHouse 24.x+; the other four are fine on 22.x+. README and CHANGELOG updated.

Unrelated, but noticed while running the suite: `TestFetching::test_explain_with_fetch` fails on current master against ClickHouse 26.7 — `EXPLAIN SELECT 1` now returns an empty line in the middle of its output, which becomes an empty `Record`. Not touched here.
